### PR TITLE
Checkboxes with follow up from Alaska project.

### DIFF
--- a/app/assets/javascripts/cfa_styleguide_main.js
+++ b/app/assets/javascripts/cfa_styleguide_main.js
@@ -136,6 +136,51 @@ var followUpQuestion = (function() {
   }
 })();
 
+const followUpCheckBoxes = (function() {
+  const fUQCB = {
+    init: function() {
+      const checkBoxes = $("input:checkbox");
+      const followUp = $('.question-with-follow-up__follow-up');
+
+      const showChecked = function() {
+        checkBoxes.each(function(index, value){
+          const target = $("input[data-follow-up='" + value.dataset.followUpTarget + "']");
+          if ($(value).is(':checked')) {
+            followUp.show();
+            target.parents(".form-group").show()
+          } else {
+            target.parents(".form-group").hide()
+          }
+        });
+      };
+
+      showChecked();
+
+      // show or hide the follow up dropdown
+      checkBoxes.change(function() {
+        // keep visible if any checkboxes checked
+        if (checkBoxes.is(":checked")) {
+          followUp.show();
+        } else {
+          followUp.hide();
+        }
+
+        // show followup inputs
+        showChecked();
+      });
+
+      // show errors
+      if (followUp.find('div.field_with_errors').length > 0) {
+        followUp.show();
+        showChecked();
+      }
+    }
+  };
+  return {
+    init: fUQCB.init
+  }
+})();
+
 var revealer = (function() {
   var rv = {
     init: function() {
@@ -239,6 +284,7 @@ $(document).ready(function() {
   radioSelector.init();
   checkboxSelector.init();
   followUpQuestion.init();
+  followUpCheckBoxes.init();
   immediateUpload.init();
   revealer.init();
   inputGroupSelector.init();

--- a/app/helpers/cfa/styleguide/cfa_form_builder.rb
+++ b/app/helpers/cfa/styleguide/cfa_form_builder.rb
@@ -93,6 +93,56 @@ module Cfa
         HTML
       end
 
+      def cfa_checkbox_set_with_follow_up(
+        method,
+        collection,
+        label_text: "",
+        help_text: nil,
+        optional: false,
+        legend_class: "",
+        follow_up: nil
+      )
+
+        checkbox_html = collection.map do |item|
+          <<~HTML.html_safe
+            <label class="checkbox">
+              #{check_box(item[:method], "data-follow-up-target": item[:method], class: "checkbox-with-follow-up")}  #{item[:label]}
+            </label>
+          HTML
+        end.join.html_safe
+    
+        follow_up_html = collection.map do |item|
+          cfa_input_field(
+            item[:data_follow_up][:method],
+            item[:data_follow_up][:label],
+            options: {
+              "data-follow-up": item[:method]
+            },
+            type: item[:data_follow_up].fetch(:type, "text")
+          )
+        end.join.html_safe
+    
+        <<~HTML.html_safe
+          <div class="question-with-follow-up">
+            <div class="question-with-follow-up__question">
+              <fieldset class="input-group form-group#{error_state(object, method)}">
+                #{fieldset_label_contents(
+                  label_text: label_text,
+                  help_text: help_text,
+                  legend_class: legend_class,
+                  optional: optional,
+                )}
+                #{checkbox_html}
+                #{errors_for(object, method)}
+              </fieldset>
+            </div>
+            <div class="question-with-follow-up__follow-up">
+              #{follow_up_html}
+            </div>
+          </div>
+        HTML
+      end
+
       def cfa_input_field(
         method,
         label_text,

--- a/app/views/cfa/styleguide/pages/form_builder.html.erb
+++ b/app/views/cfa/styleguide/pages/form_builder.html.erb
@@ -14,6 +14,7 @@
 <%= render 'section', title: 'Date select', example: 'form_builder/cfa_date_select' %>
 <%= render 'section', title: 'Checkbox set', example: 'form_builder/cfa_checkbox_set' %>
 <%= render 'section', title: 'Checkbox set with none', example: 'form_builder/cfa_checkbox_set_with_none' %>
+<%= render 'section', title: 'Checkbox set with follow up', example: 'form_builder/cfa_checkbox_set_with_follow_up' %>
 <%= render 'section', title: 'Radio set', example: 'form_builder/cfa_radio_set' %>
 <%= render 'section', title: 'Radio set with follow up', example: 'form_builder/cfa_radio_set_with_follow_up' %>
 <%= render 'section', title: 'Single tap button', example: 'form_builder/cfa_single_tap_button' %>


### PR DESCRIPTION
Pulled over the checkbox set with follow ups from the [alaska code base](https://github.com/codeforamerica/alaska-benefits).

It works in that project, yet doesn't play nice with all the other examples on the styleguide page yet.

<img width="652" alt="Screen Shot 2019-05-22 at 10 41 35 AM" src="https://user-images.githubusercontent.com/595778/58196018-30ebe400-7c7e-11e9-81f7-2d6f6665224f.png">
