### PR TITLE
Update branding to Honeycrisp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,182 +1,182 @@
 # Change Log
 
-## [v0.9.0](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.9.0) (2019-11-05)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.8.0...v0.9.0)
+## [v0.9.0](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.9.0) (2019-11-05)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.8.0...v0.9.0)
 
 **Merged pull requests:**
 
-- Add migration guide [\#130](https://github.com/codeforamerica/cfa-styleguide-gem/pull/130) ([hartsick](https://github.com/hartsick))
-- Accessibility design details [\#123](https://github.com/codeforamerica/cfa-styleguide-gem/pull/123) ([norrishung](https://github.com/norrishung))
+- Add migration guide [\#130](https://github.com/codeforamerica/honeycrisp-gem/pull/130) ([hartsick](https://github.com/hartsick))
+- Accessibility design details [\#123](https://github.com/codeforamerica/honeycrisp-gem/pull/123) ([norrishung](https://github.com/norrishung))
 
-## [v0.8.0](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.8.0) (2019-10-10)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.7.1...v0.8.0)
-
-**Merged pull requests:**
-
-- Add crossmark and checkmark list patterns to design system [\#127](https://github.com/codeforamerica/cfa-styleguide-gem/pull/127) ([norrishung](https://github.com/norrishung))
-
-## [v0.7.1](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.7.1) (2019-10-09)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.7.0...v0.7.1)
+## [v0.8.0](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.8.0) (2019-10-10)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.7.1...v0.8.0)
 
 **Merged pull requests:**
 
-- Bump rubyzip from 1.2.2 to 1.3.0 [\#126](https://github.com/codeforamerica/cfa-styleguide-gem/pull/126) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Add crossmark and checkmark list patterns to design system [\#127](https://github.com/codeforamerica/honeycrisp-gem/pull/127) ([norrishung](https://github.com/norrishung))
 
-## [v0.7.0](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.7.0) (2019-10-08)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.6.5...v0.7.0)
+## [v0.7.1](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.7.1) (2019-10-09)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.7.0...v0.7.1)
+
+**Merged pull requests:**
+
+- Bump rubyzip from 1.2.2 to 1.3.0 [\#126](https://github.com/codeforamerica/honeycrisp-gem/pull/126) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v0.7.0](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.7.0) (2019-10-08)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.6.5...v0.7.0)
 
 **Implemented enhancements:**
 
-- Add more documentation of spacing classes [\#114](https://github.com/codeforamerica/cfa-styleguide-gem/issues/114)
-- Add optional text label for step progress bar [\#105](https://github.com/codeforamerica/cfa-styleguide-gem/issues/105)
+- Add more documentation of spacing classes [\#114](https://github.com/codeforamerica/honeycrisp-gem/issues/114)
+- Add optional text label for step progress bar [\#105](https://github.com/codeforamerica/honeycrisp-gem/issues/105)
 
 **Merged pull requests:**
 
-- Documentation page: display explanation between example and code [\#128](https://github.com/codeforamerica/cfa-styleguide-gem/pull/128) ([jenny-heath](https://github.com/jenny-heath))
-- Adding an accordion pattern [\#125](https://github.com/codeforamerica/cfa-styleguide-gem/pull/125) ([norrishung](https://github.com/norrishung))
-- Hide unchecked follow up questions on page load [\#119](https://github.com/codeforamerica/cfa-styleguide-gem/pull/119) ([tdooner](https://github.com/tdooner))
-- Fix follow-up to work for single checkbox [\#118](https://github.com/codeforamerica/cfa-styleguide-gem/pull/118) ([tdooner](https://github.com/tdooner))
+- Documentation page: display explanation between example and code [\#128](https://github.com/codeforamerica/honeycrisp-gem/pull/128) ([jenny-heath](https://github.com/jenny-heath))
+- Adding an accordion pattern [\#125](https://github.com/codeforamerica/honeycrisp-gem/pull/125) ([norrishung](https://github.com/norrishung))
+- Hide unchecked follow up questions on page load [\#119](https://github.com/codeforamerica/honeycrisp-gem/pull/119) ([tdooner](https://github.com/tdooner))
+- Fix follow-up to work for single checkbox [\#118](https://github.com/codeforamerica/honeycrisp-gem/pull/118) ([tdooner](https://github.com/tdooner))
 
-## [v0.6.5](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.6.5) (2019-07-15)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.6.4...v0.6.5)
+## [v0.6.5](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.6.5) (2019-07-15)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.6.4...v0.6.5)
 
 **Implemented enhancements:**
 
-- Explore screenshot testing [\#51](https://github.com/codeforamerica/cfa-styleguide-gem/issues/51)
+- Explore screenshot testing [\#51](https://github.com/codeforamerica/honeycrisp-gem/issues/51)
 
 **Merged pull requests:**
 
-- Upgrade lodash to address CVE [\#117](https://github.com/codeforamerica/cfa-styleguide-gem/pull/117) ([hartsick](https://github.com/hartsick))
-- Update toolbar for new GCF behaviors [\#116](https://github.com/codeforamerica/cfa-styleguide-gem/pull/116) ([tdooner](https://github.com/tdooner))
+- Upgrade lodash to address CVE [\#117](https://github.com/codeforamerica/honeycrisp-gem/pull/117) ([hartsick](https://github.com/hartsick))
+- Update toolbar for new GCF behaviors [\#116](https://github.com/codeforamerica/honeycrisp-gem/pull/116) ([tdooner](https://github.com/tdooner))
 
-## [v0.6.4](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.6.4) (2019-07-01)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.6.2...v0.6.4)
-
-**Merged pull requests:**
-
-- Simplified step-bar-description [\#113](https://github.com/codeforamerica/cfa-styleguide-gem/pull/113) ([embarnard](https://github.com/embarnard))
-- Add a section about spacing to reference page [\#111](https://github.com/codeforamerica/cfa-styleguide-gem/pull/111) ([jenny-heath](https://github.com/jenny-heath))
-- Fix bug on step progress bar: increment current\_step on a 0 index system [\#110](https://github.com/codeforamerica/cfa-styleguide-gem/pull/110) ([embarnard](https://github.com/embarnard))
-
-## [v0.6.2](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.6.2) (2019-06-25)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.6.1...v0.6.2)
+## [v0.6.4](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.6.4) (2019-07-01)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.6.2...v0.6.4)
 
 **Merged pull requests:**
 
-- added student pair emoji [\#109](https://github.com/codeforamerica/cfa-styleguide-gem/pull/109) ([embarnard](https://github.com/embarnard))
-- Add emoji for "older man and woman" [\#108](https://github.com/codeforamerica/cfa-styleguide-gem/pull/108) ([tdooner](https://github.com/tdooner))
-- Add support for optional progress step bar labels [\#107](https://github.com/codeforamerica/cfa-styleguide-gem/pull/107) ([hartsick](https://github.com/hartsick))
+- Simplified step-bar-description [\#113](https://github.com/codeforamerica/honeycrisp-gem/pull/113) ([embarnard](https://github.com/embarnard))
+- Add a section about spacing to reference page [\#111](https://github.com/codeforamerica/honeycrisp-gem/pull/111) ([jenny-heath](https://github.com/jenny-heath))
+- Fix bug on step progress bar: increment current\_step on a 0 index system [\#110](https://github.com/codeforamerica/honeycrisp-gem/pull/110) ([embarnard](https://github.com/embarnard))
 
-## [v0.6.1](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.6.1) (2019-06-06)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.6.0...v0.6.1)
-
-**Merged pull requests:**
-
-- Add new type of notice [\#103](https://github.com/codeforamerica/cfa-styleguide-gem/pull/103) ([jenny-heath](https://github.com/jenny-heath))
-
-## [v0.6.0](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.6.0) (2019-05-21)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.5.11...v0.6.0)
+## [v0.6.2](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.6.2) (2019-06-25)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.6.1...v0.6.2)
 
 **Merged pull requests:**
 
-- Accessibility improvements from GCF audit [\#101](https://github.com/codeforamerica/cfa-styleguide-gem/pull/101) ([hartsick](https://github.com/hartsick))
+- added student pair emoji [\#109](https://github.com/codeforamerica/honeycrisp-gem/pull/109) ([embarnard](https://github.com/embarnard))
+- Add emoji for "older man and woman" [\#108](https://github.com/codeforamerica/honeycrisp-gem/pull/108) ([tdooner](https://github.com/tdooner))
+- Add support for optional progress step bar labels [\#107](https://github.com/codeforamerica/honeycrisp-gem/pull/107) ([hartsick](https://github.com/hartsick))
 
-## [v0.5.11](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.5.11) (2019-04-04)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.5.10...v0.5.11)
+## [v0.6.1](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.6.1) (2019-06-06)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.6.0...v0.6.1)
+
+**Merged pull requests:**
+
+- Add new type of notice [\#103](https://github.com/codeforamerica/honeycrisp-gem/pull/103) ([jenny-heath](https://github.com/jenny-heath))
+
+## [v0.6.0](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.6.0) (2019-05-21)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.5.11...v0.6.0)
+
+**Merged pull requests:**
+
+- Accessibility improvements from GCF audit [\#101](https://github.com/codeforamerica/honeycrisp-gem/pull/101) ([hartsick](https://github.com/hartsick))
+
+## [v0.5.11](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.5.11) (2019-04-04)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.5.10...v0.5.11)
 
 **Fixed bugs:**
 
-- Incrementer has vestigial arrows in Firefox [\#94](https://github.com/codeforamerica/cfa-styleguide-gem/issues/94)
-- Hitting Command+0 in Firefox causes the page footer to move [\#14](https://github.com/codeforamerica/cfa-styleguide-gem/issues/14)
+- Incrementer has vestigial arrows in Firefox [\#94](https://github.com/codeforamerica/honeycrisp-gem/issues/94)
+- Hitting Command+0 in Firefox causes the page footer to move [\#14](https://github.com/codeforamerica/honeycrisp-gem/issues/14)
 
 **Merged pull requests:**
 
-- Remove stepper arrows for number input on Firefox [\#95](https://github.com/codeforamerica/cfa-styleguide-gem/pull/95) ([hartsick](https://github.com/hartsick))
-- Add Percy snapshot to CircleCI [\#93](https://github.com/codeforamerica/cfa-styleguide-gem/pull/93) ([bensheldon](https://github.com/bensheldon))
-- Refactor all styleguide examples to use partial; add link to isolated example [\#89](https://github.com/codeforamerica/cfa-styleguide-gem/pull/89) ([bensheldon](https://github.com/bensheldon))
-- Add link to Github repo and issue submission [\#88](https://github.com/codeforamerica/cfa-styleguide-gem/pull/88) ([hartsick](https://github.com/hartsick))
+- Remove stepper arrows for number input on Firefox [\#95](https://github.com/codeforamerica/honeycrisp-gem/pull/95) ([hartsick](https://github.com/hartsick))
+- Add Percy snapshot to CircleCI [\#93](https://github.com/codeforamerica/honeycrisp-gem/pull/93) ([bensheldon](https://github.com/bensheldon))
+- Refactor all styleguide examples to use partial; add link to isolated example [\#89](https://github.com/codeforamerica/honeycrisp-gem/pull/89) ([bensheldon](https://github.com/bensheldon))
+- Add link to Github repo and issue submission [\#88](https://github.com/codeforamerica/honeycrisp-gem/pull/88) ([hartsick](https://github.com/hartsick))
 
-## [v0.5.10](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.5.10) (2019-02-16)
-[Full Changelog](https://github.com/codeforamerica/cfa-styleguide-gem/compare/v0.5.9...v0.5.10)
+## [v0.5.10](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.5.10) (2019-02-16)
+[Full Changelog](https://github.com/codeforamerica/honeycrisp-gem/compare/v0.5.9...v0.5.10)
 
 **Implemented enhancements:**
 
-- Set up rubocop and add to CI [\#86](https://github.com/codeforamerica/cfa-styleguide-gem/issues/86)
-- Create links to individual components on reference page [\#53](https://github.com/codeforamerica/cfa-styleguide-gem/issues/53)
-- Add gem release rake task [\#52](https://github.com/codeforamerica/cfa-styleguide-gem/issues/52)
-- Add show-more component [\#30](https://github.com/codeforamerica/cfa-styleguide-gem/issues/30)
+- Set up rubocop and add to CI [\#86](https://github.com/codeforamerica/honeycrisp-gem/issues/86)
+- Create links to individual components on reference page [\#53](https://github.com/codeforamerica/honeycrisp-gem/issues/53)
+- Add gem release rake task [\#52](https://github.com/codeforamerica/honeycrisp-gem/issues/52)
+- Add show-more component [\#30](https://github.com/codeforamerica/honeycrisp-gem/issues/30)
 
 **Merged pull requests:**
 
-- Add rubocop [\#87](https://github.com/codeforamerica/cfa-styleguide-gem/pull/87) ([hartsick](https://github.com/hartsick))
-- Make accessibility improvements [\#83](https://github.com/codeforamerica/cfa-styleguide-gem/pull/83) ([bensheldon](https://github.com/bensheldon))
-- Add show more pattern to molecules [\#82](https://github.com/codeforamerica/cfa-styleguide-gem/pull/82) ([anule](https://github.com/anule))
-- Add anchorlink to individual examples [\#81](https://github.com/codeforamerica/cfa-styleguide-gem/pull/81) ([bensheldon](https://github.com/bensheldon))
-- Add Brewfile and instructions for Chromedriver [\#80](https://github.com/codeforamerica/cfa-styleguide-gem/pull/80) ([bensheldon](https://github.com/bensheldon))
-- Add changelog generation and instructions [\#73](https://github.com/codeforamerica/cfa-styleguide-gem/pull/73) ([hartsick](https://github.com/hartsick))
+- Add rubocop [\#87](https://github.com/codeforamerica/honeycrisp-gem/pull/87) ([hartsick](https://github.com/hartsick))
+- Make accessibility improvements [\#83](https://github.com/codeforamerica/honeycrisp-gem/pull/83) ([bensheldon](https://github.com/bensheldon))
+- Add show more pattern to molecules [\#82](https://github.com/codeforamerica/honeycrisp-gem/pull/82) ([anule](https://github.com/anule))
+- Add anchorlink to individual examples [\#81](https://github.com/codeforamerica/honeycrisp-gem/pull/81) ([bensheldon](https://github.com/bensheldon))
+- Add Brewfile and instructions for Chromedriver [\#80](https://github.com/codeforamerica/honeycrisp-gem/pull/80) ([bensheldon](https://github.com/bensheldon))
+- Add changelog generation and instructions [\#73](https://github.com/codeforamerica/honeycrisp-gem/pull/73) ([hartsick](https://github.com/hartsick))
 
-## [v0.5.9](https://github.com/codeforamerica/cfa-styleguide-gem/tree/v0.5.9) (2019-02-08)
+## [v0.5.9](https://github.com/codeforamerica/honeycrisp-gem/tree/v0.5.9) (2019-02-08)
 **Implemented enhancements:**
 
-- Update error message examples [\#62](https://github.com/codeforamerica/cfa-styleguide-gem/issues/62)
-- Audit styleguide references to find unused pages [\#58](https://github.com/codeforamerica/cfa-styleguide-gem/issues/58)
-- Make styleguide Sass variables available for use in host application [\#55](https://github.com/codeforamerica/cfa-styleguide-gem/issues/55)
-- Add link to non-index styleguide pages [\#39](https://github.com/codeforamerica/cfa-styleguide-gem/issues/39)
-- Create a styleguide reference for form builder [\#27](https://github.com/codeforamerica/cfa-styleguide-gem/issues/27)
-- Create an emoji index [\#24](https://github.com/codeforamerica/cfa-styleguide-gem/issues/24)
-- Update form organisms  [\#22](https://github.com/codeforamerica/cfa-styleguide-gem/issues/22)
-- Allow for overriding variables [\#17](https://github.com/codeforamerica/cfa-styleguide-gem/issues/17)
-- Set up CI [\#4](https://github.com/codeforamerica/cfa-styleguide-gem/issues/4)
-- Form cards are missing top border [\#2](https://github.com/codeforamerica/cfa-styleguide-gem/issues/2)
+- Update error message examples [\#62](https://github.com/codeforamerica/honeycrisp-gem/issues/62)
+- Audit styleguide references to find unused pages [\#58](https://github.com/codeforamerica/honeycrisp-gem/issues/58)
+- Make styleguide Sass variables available for use in host application [\#55](https://github.com/codeforamerica/honeycrisp-gem/issues/55)
+- Add link to non-index styleguide pages [\#39](https://github.com/codeforamerica/honeycrisp-gem/issues/39)
+- Create a styleguide reference for form builder [\#27](https://github.com/codeforamerica/honeycrisp-gem/issues/27)
+- Create an emoji index [\#24](https://github.com/codeforamerica/honeycrisp-gem/issues/24)
+- Update form organisms  [\#22](https://github.com/codeforamerica/honeycrisp-gem/issues/22)
+- Allow for overriding variables [\#17](https://github.com/codeforamerica/honeycrisp-gem/issues/17)
+- Set up CI [\#4](https://github.com/codeforamerica/honeycrisp-gem/issues/4)
+- Form cards are missing top border [\#2](https://github.com/codeforamerica/honeycrisp-gem/issues/2)
 
 **Fixed bugs:**
 
-- Fix reveal pattern code [\#43](https://github.com/codeforamerica/cfa-styleguide-gem/issues/43)
-- Teal primary button fails accessibility contrast check [\#18](https://github.com/codeforamerica/cfa-styleguide-gem/issues/18)
+- Fix reveal pattern code [\#43](https://github.com/codeforamerica/honeycrisp-gem/issues/43)
+- Teal primary button fails accessibility contrast check [\#18](https://github.com/codeforamerica/honeycrisp-gem/issues/18)
 
 **Closed issues:**
 
-- Delete unused styleguide pages and fix navigation [\#65](https://github.com/codeforamerica/cfa-styleguide-gem/issues/65)
-- Create deployed styleguide [\#56](https://github.com/codeforamerica/cfa-styleguide-gem/issues/56)
-- Make a step progress bar pattern [\#33](https://github.com/codeforamerica/cfa-styleguide-gem/issues/33)
-- Gem doesn't provide its own layout file [\#9](https://github.com/codeforamerica/cfa-styleguide-gem/issues/9)
-- Fix dropdown text wrapping [\#8](https://github.com/codeforamerica/cfa-styleguide-gem/issues/8)
+- Delete unused styleguide pages and fix navigation [\#65](https://github.com/codeforamerica/honeycrisp-gem/issues/65)
+- Create deployed styleguide [\#56](https://github.com/codeforamerica/honeycrisp-gem/issues/56)
+- Make a step progress bar pattern [\#33](https://github.com/codeforamerica/honeycrisp-gem/issues/33)
+- Gem doesn't provide its own layout file [\#9](https://github.com/codeforamerica/honeycrisp-gem/issues/9)
+- Fix dropdown text wrapping [\#8](https://github.com/codeforamerica/honeycrisp-gem/issues/8)
 
 **Merged pull requests:**
 
-- Add axe-matchers; test all examples for accessibility [\#69](https://github.com/codeforamerica/cfa-styleguide-gem/pull/69) ([bensheldon](https://github.com/bensheldon))
-- Add note about changes required to enable variable usage [\#68](https://github.com/codeforamerica/cfa-styleguide-gem/pull/68) ([zaksoup](https://github.com/zaksoup))
-- Allow overriding variables [\#67](https://github.com/codeforamerica/cfa-styleguide-gem/pull/67) ([bengolder](https://github.com/bengolder))
-- Remove unused styleguide pages [\#66](https://github.com/codeforamerica/cfa-styleguide-gem/pull/66) ([hartsick](https://github.com/hartsick))
-- Add an emoji index [\#64](https://github.com/codeforamerica/cfa-styleguide-gem/pull/64) ([anule](https://github.com/anule))
-- Update styleguide error message [\#63](https://github.com/codeforamerica/cfa-styleguide-gem/pull/63) ([hartsick](https://github.com/hartsick))
-- Add detective woman emoji [\#61](https://github.com/codeforamerica/cfa-styleguide-gem/pull/61) ([zaksoup](https://github.com/zaksoup))
-- Transition to using system tests [\#59](https://github.com/codeforamerica/cfa-styleguide-gem/pull/59) ([hartsick](https://github.com/hartsick))
-- Add version number to page title [\#57](https://github.com/codeforamerica/cfa-styleguide-gem/pull/57) ([hartsick](https://github.com/hartsick))
-- Add cfa\_select to the form builder [\#50](https://github.com/codeforamerica/cfa-styleguide-gem/pull/50) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Create reusable components for molecules and atoms [\#49](https://github.com/codeforamerica/cfa-styleguide-gem/pull/49) ([bensheldon](https://github.com/bensheldon))
-- Include single tap button examples in the form builder section [\#48](https://github.com/codeforamerica/cfa-styleguide-gem/pull/48) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Add validations to form builder examples [\#47](https://github.com/codeforamerica/cfa-styleguide-gem/pull/47) ([hartsick](https://github.com/hartsick))
-- Use example partials for form builder [\#45](https://github.com/codeforamerica/cfa-styleguide-gem/pull/45) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Formbuilder styleguide reference [\#44](https://github.com/codeforamerica/cfa-styleguide-gem/pull/44) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Add links to other styleguide pages [\#41](https://github.com/codeforamerica/cfa-styleguide-gem/pull/41) ([hartsick](https://github.com/hartsick))
-- Add progress step bar [\#40](https://github.com/codeforamerica/cfa-styleguide-gem/pull/40) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Add development Rails server and update development instructions [\#37](https://github.com/codeforamerica/cfa-styleguide-gem/pull/37) ([bensheldon](https://github.com/bensheldon))
-- Add js for checkbox set with none [\#35](https://github.com/codeforamerica/cfa-styleguide-gem/pull/35) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Add cfa\_single\_tap\_button to FormBuilder [\#32](https://github.com/codeforamerica/cfa-styleguide-gem/pull/32) ([hartsick](https://github.com/hartsick))
-- Update gems [\#31](https://github.com/codeforamerica/cfa-styleguide-gem/pull/31) ([hartsick](https://github.com/hartsick))
-- Add cfa\_checkbox\_set to form builder [\#29](https://github.com/codeforamerica/cfa-styleguide-gem/pull/29) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Add CfaFormBuilder [\#26](https://github.com/codeforamerica/cfa-styleguide-gem/pull/26) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- bump rack due to security vulnerability [\#25](https://github.com/codeforamerica/cfa-styleguide-gem/pull/25) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
-- Bump gem version [\#23](https://github.com/codeforamerica/cfa-styleguide-gem/pull/23) ([hartsick](https://github.com/hartsick))
-- Darken base teal color to improve contrast [\#19](https://github.com/codeforamerica/cfa-styleguide-gem/pull/19) ([hartsick](https://github.com/hartsick))
-- Pull in latest GCF styleguide [\#12](https://github.com/codeforamerica/cfa-styleguide-gem/pull/12) ([hartsick](https://github.com/hartsick))
-- Fix styling on non-main styleguide pages [\#11](https://github.com/codeforamerica/cfa-styleguide-gem/pull/11) ([hartsick](https://github.com/hartsick))
-- Declare layout for Styleguide [\#10](https://github.com/codeforamerica/cfa-styleguide-gem/pull/10) ([hartsick](https://github.com/hartsick))
-- Make radio button 'is-selected' more permissive wrt HTML structure [\#7](https://github.com/codeforamerica/cfa-styleguide-gem/pull/7) ([hartsick](https://github.com/hartsick))
-- Add CircleCI config [\#5](https://github.com/codeforamerica/cfa-styleguide-gem/pull/5) ([hartsick](https://github.com/hartsick))
-- Fold in latest changes from GCF styleguide [\#3](https://github.com/codeforamerica/cfa-styleguide-gem/pull/3) ([hartsick](https://github.com/hartsick))
-- Modify javascript for inclusion in gem [\#1](https://github.com/codeforamerica/cfa-styleguide-gem/pull/1) ([hartsick](https://github.com/hartsick))
+- Add axe-matchers; test all examples for accessibility [\#69](https://github.com/codeforamerica/honeycrisp-gem/pull/69) ([bensheldon](https://github.com/bensheldon))
+- Add note about changes required to enable variable usage [\#68](https://github.com/codeforamerica/honeycrisp-gem/pull/68) ([zaksoup](https://github.com/zaksoup))
+- Allow overriding variables [\#67](https://github.com/codeforamerica/honeycrisp-gem/pull/67) ([bengolder](https://github.com/bengolder))
+- Remove unused styleguide pages [\#66](https://github.com/codeforamerica/honeycrisp-gem/pull/66) ([hartsick](https://github.com/hartsick))
+- Add an emoji index [\#64](https://github.com/codeforamerica/honeycrisp-gem/pull/64) ([anule](https://github.com/anule))
+- Update styleguide error message [\#63](https://github.com/codeforamerica/honeycrisp-gem/pull/63) ([hartsick](https://github.com/hartsick))
+- Add detective woman emoji [\#61](https://github.com/codeforamerica/honeycrisp-gem/pull/61) ([zaksoup](https://github.com/zaksoup))
+- Transition to using system tests [\#59](https://github.com/codeforamerica/honeycrisp-gem/pull/59) ([hartsick](https://github.com/hartsick))
+- Add version number to page title [\#57](https://github.com/codeforamerica/honeycrisp-gem/pull/57) ([hartsick](https://github.com/hartsick))
+- Add cfa\_select to the form builder [\#50](https://github.com/codeforamerica/honeycrisp-gem/pull/50) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Create reusable components for molecules and atoms [\#49](https://github.com/codeforamerica/honeycrisp-gem/pull/49) ([bensheldon](https://github.com/bensheldon))
+- Include single tap button examples in the form builder section [\#48](https://github.com/codeforamerica/honeycrisp-gem/pull/48) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Add validations to form builder examples [\#47](https://github.com/codeforamerica/honeycrisp-gem/pull/47) ([hartsick](https://github.com/hartsick))
+- Use example partials for form builder [\#45](https://github.com/codeforamerica/honeycrisp-gem/pull/45) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Formbuilder styleguide reference [\#44](https://github.com/codeforamerica/honeycrisp-gem/pull/44) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Add links to other styleguide pages [\#41](https://github.com/codeforamerica/honeycrisp-gem/pull/41) ([hartsick](https://github.com/hartsick))
+- Add progress step bar [\#40](https://github.com/codeforamerica/honeycrisp-gem/pull/40) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Add development Rails server and update development instructions [\#37](https://github.com/codeforamerica/honeycrisp-gem/pull/37) ([bensheldon](https://github.com/bensheldon))
+- Add js for checkbox set with none [\#35](https://github.com/codeforamerica/honeycrisp-gem/pull/35) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Add cfa\_single\_tap\_button to FormBuilder [\#32](https://github.com/codeforamerica/honeycrisp-gem/pull/32) ([hartsick](https://github.com/hartsick))
+- Update gems [\#31](https://github.com/codeforamerica/honeycrisp-gem/pull/31) ([hartsick](https://github.com/hartsick))
+- Add cfa\_checkbox\_set to form builder [\#29](https://github.com/codeforamerica/honeycrisp-gem/pull/29) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Add CfaFormBuilder [\#26](https://github.com/codeforamerica/honeycrisp-gem/pull/26) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- bump rack due to security vulnerability [\#25](https://github.com/codeforamerica/honeycrisp-gem/pull/25) ([wschaefer-cfa](https://github.com/wschaefer-cfa))
+- Bump gem version [\#23](https://github.com/codeforamerica/honeycrisp-gem/pull/23) ([hartsick](https://github.com/hartsick))
+- Darken base teal color to improve contrast [\#19](https://github.com/codeforamerica/honeycrisp-gem/pull/19) ([hartsick](https://github.com/hartsick))
+- Pull in latest GCF styleguide [\#12](https://github.com/codeforamerica/honeycrisp-gem/pull/12) ([hartsick](https://github.com/hartsick))
+- Fix styling on non-main styleguide pages [\#11](https://github.com/codeforamerica/honeycrisp-gem/pull/11) ([hartsick](https://github.com/hartsick))
+- Declare layout for Styleguide [\#10](https://github.com/codeforamerica/honeycrisp-gem/pull/10) ([hartsick](https://github.com/hartsick))
+- Make radio button 'is-selected' more permissive wrt HTML structure [\#7](https://github.com/codeforamerica/honeycrisp-gem/pull/7) ([hartsick](https://github.com/hartsick))
+- Add CircleCI config [\#5](https://github.com/codeforamerica/honeycrisp-gem/pull/5) ([hartsick](https://github.com/hartsick))
+- Fold in latest changes from GCF styleguide [\#3](https://github.com/codeforamerica/honeycrisp-gem/pull/3) ([hartsick](https://github.com/hartsick))
+- Modify javascript for inclusion in gem [\#1](https://github.com/codeforamerica/honeycrisp-gem/pull/1) ([hartsick](https://github.com/hartsick))
 
 
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,7 +2,7 @@
 
 ## Migrating from <= 0.8.x to 0.9.0
 
-For a full diff of changes, view the [pull request](https://github.com/codeforamerica/cfa-styleguide-gem/pull/123/files). A summary of significant changes is below.
+For a full diff of changes, view the [pull request](https://github.com/codeforamerica/honeycrisp-gem/pull/123/files). A summary of significant changes is below.
 
 ### Breaking changes: SASS variables
 In `0.9.0`, various SASS variables have been removed and will cause breakage if they're continued to be used in the host application.
@@ -39,4 +39,4 @@ Spacing classes have been moved from `utilities.scss` to `spacing.scss`.
 
 ### Removals: CSS classes
 A handful of CSS classes have been removed. If your project needs them or you're concerned 
-about breaking, review the [diff](https://github.com/codeforamerica/cfa-styleguide-gem/pull/123/files).
+about breaking, review the [diff](https://github.com/codeforamerica/honeycrisp-gem/pull/123/files).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Code for America Styleguide
+# Honeycrisp Design System
 
 A gem including base styles and javascript for Code for America products, for use in Rails applications.
 
-View the current version of the styleguide at [https://cfa-styleguide.herokuapp.com](https://cfa-styleguide.herokuapp.com).
+View the current version of the styleguide at [https://honeycrisp.herokuapp.com](https://cfa-styleguide.herokuapp.com).
 
 ## Contributing
 
@@ -15,7 +15,7 @@ If you have any thoughts or questions about the project, get in touch at <a href
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/cfa-styleguide-gem'
+gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem'
 ```
 
 And then execute:
@@ -92,7 +92,7 @@ If the gem is being used in another project's Gemfile, the source can be locally
 
 1. Change the bundler configuration to use the local gem repository
 
-    In the terminal, run `bundle config local.cfa-styleguide /path/to/cfa-styleguide-gem`
+    In the terminal, run `bundle config local.cfa-styleguide /path/to/honeycrisp-gem`
 
     To install this gem onto your local machine, run `bundle exec rake install`.
   
@@ -103,14 +103,14 @@ If the gem is being used in another project's Gemfile, the source can be locally
     Alternatively, you can change host project's `Gemfile` to point to a local copy of this repository. For example, changing:
 
     ```
-    gem 'cfa-styleguide', '~> 0.7', github: 'codeforamerica/cfa-styleguide-gem'
+    gem 'cfa-styleguide', '~> 0.7', github: 'codeforamerica/honeycrisp-gem'
     ```
     to
     ```
-    gem 'cfa-styleguide', '~> 0.7', path: '../cfa-styleguide-gem'
+    gem 'cfa-styleguide', '~> 0.7', path: '../honeycrisp-gem'
     ```
     
-    where `../cfa-styleguide-gem` is the path (relative or absolute) to this repo on the local filesystem.
+    where `../honeycrisp-gem` is the path (relative or absolute) to this repo on the local filesystem.
     
     After updating the `Gemfile` with these changes, you will need to run `bundle install`.
     

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.user = "codeforamerica"
-  config.project = "cfa-styleguide-gem"
+  config.project = "honeycrisp-gem"
   config.future_release = "v#{Cfa::Styleguide::VERSION}"
 end
 

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "cfa-styleguide-gem",
+  "name": "honeycrisp-gem",
   "scripts": {},
   "env": {
     "BUNDLE_WITHOUT": {

--- a/app/views/cfa/styleguide/pages/index.html.erb
+++ b/app/views/cfa/styleguide/pages/index.html.erb
@@ -4,7 +4,7 @@
     <div class="grid__item width-two-thirds">
       <h1>Honeycrisp Design System</h1>
       <p>This is the official design system for products at Code for America.</p>
-      <p>Have a suggestion? <a href="https://github.com/codeforamerica/cfa-styleguide-gem/issues">Submit it as an issue</a> on <a href="https://github.com/codeforamerica/cfa-styleguide-gem">the Github repo!</a> Questions? Contact us at <a href="mailto:styleguide@codeforamerica.org">styleguide@codeforamerica.org</a>.</p>
+      <p>Have a suggestion? <a href="https://github.com/codeforamerica/honeycrisp-gem/issues">Submit it as an issue</a> on <a href="https://github.com/codeforamerica/honeycrisp-gem">the Github repo!</a> Questions? Contact us at <a href="mailto:styleguide@codeforamerica.org">styleguide@codeforamerica.org</a>.</p>
     </div>
   </div>
 </div>

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -19,7 +19,9 @@
     <header class="main-header">
       <div class="toolbar">
         <div class="toolbar__left">
-          <h1 class="main-header__title"><a class="main-header__logo" href="#">Honeycrisp Design System v<%= Cfa::Styleguide::VERSION %></a></h1>
+          <h1 class="main-header__title">
+            <%= link_to "Honeycrisp Design System v#{Cfa::Styleguide::VERSION}", styleguide_main_path, class: %w{main-header__logo} %>
+          </h1>
         </div>
         <div class="toolbar__right">
           <%= link_to "Atoms", styleguide_main_path(anchor: "atoms"), class: %w{toolbar__item text--small link--subtle} %>
@@ -37,7 +39,7 @@
     <div class="grid">
       <div class="grid__item">
         <div class="main-footer__legal">
-          <p>The CfA Styleguide is a pattern library developed by <a class="link--subtle" href="#">Code for America</a>.</p>
+          <p>Honeycrisp is a design system developed by <a class="link--subtle" href="https://codeforamerica.org">Code for America</a>.</p>
         </div>
       </div>
     </div>

--- a/cfa-styleguide.gemspec
+++ b/cfa-styleguide.gemspec
@@ -5,13 +5,13 @@ require "cfa/styleguide/version"
 Gem::Specification.new do |spec|
   spec.name          = "cfa-styleguide"
   spec.version       = Cfa::Styleguide::VERSION
-  spec.authors       = ["https://github.com/codeforamerica/cfa-styleguide-gem/graphs/contributors"]
+  spec.authors       = ["https://github.com/codeforamerica/honeycrisp-gem/graphs/contributors"]
   spec.email         = ["christa@codeforamerica.org"]
 
-  spec.summary       = "A pattern library for CfA products, based on the GetCalFresh styleguide"
-  spec.description   = "Code for America Styleguide"
-  spec.homepage      = "https://github.com/codeforamerica/cfa-styleguide-gem"
-  spec.metadata      = { "documentation_uri" => "https://cfa-styleguide.herokuapp.com" }
+  spec.summary       = "A design system created for Code for America services."
+  spec.description   = "Honeycrisp Design System"
+  spec.homepage      = "https://github.com/codeforamerica/honeycrisp-gem"
+  spec.metadata      = { "documentation_uri" => "https://honeycrisp.herokuapp.com" }
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
* Update Github link to new repo name
* Update Heroku URL -> honeycrisp.herokuapp.com

Closes https://github.com/codeforamerica/honeycrisp-gem/issues/122