### PR TITLE
Adjusts how upload buttons are highlighted on focus.

### DIFF
--- a/app/assets/stylesheets/atoms/_form-elements.scss
+++ b/app/assets/stylesheets/atoms/_form-elements.scss
@@ -214,6 +214,10 @@ label {
 
 .file-upload {
   display: inline-block;
+
+  //  The ~ denotes a "subsequent sibling" per https://www.w3.org/TR/selectors-4/#general-sibling-combinators
+  //  This rule expects that an element with class .button will occur after a focused input element as children
+  //  of the .file-upload element, as is the case in the example HTML in the styleguide.
   input:focus ~ .button {
     @include outline-unconditional;
   }

--- a/app/assets/stylesheets/atoms/_form-elements.scss
+++ b/app/assets/stylesheets/atoms/_form-elements.scss
@@ -213,10 +213,9 @@ label {
 }
 
 .file-upload {
-  @include outline-within();
   display: inline-block;
-  .button {
-    margin: 0;
+  input:focus ~ .button {
+    @include outline-unconditional;
   }
 }
 

--- a/app/assets/stylesheets/atoms/_utilities.scss
+++ b/app/assets/stylesheets/atoms/_utilities.scss
@@ -81,17 +81,20 @@
   }
 }
 
+@mixin outline-unconditional() {
+  outline: none;
+  box-shadow: 0 0 0 5px $color-yellow;
+}
+
 @mixin outline() {
   &:focus {
-    outline: none;
-    box-shadow: 0 0 0 5px $color-yellow;
+    @include outline-unconditional;
   }
 }
 
 @mixin outline-within() {
   &:focus-within {
-    outline: none;
-    box-shadow: 0 0 0 5px $color-yellow;
+    @include outline-unconditional;
   }
 }
 


### PR DESCRIPTION
The previous solution had two issues: the focus was rectangular despite the rounded rect button style, and the upload button lost its spacing, causing GCF's documents upload page to lay out incorrectly. This is a bit of a sketchy fix, since it relies on the existence of an element with class 'button' (which is actually an unfocused <label> in GCF) as a sibling of the actually-focused input element (which is invisible in GCF's case). I still need to test this in other instances of GCF's usage if there are any, but wanted to push it up to let others tell me if it's totally infeasible in the meantime.