### PR TITLE
Use `identifier` to return a path for desired template.

### DIFF
--- a/app/helpers/cfa/styleguide/pages_helper.rb
+++ b/app/helpers/cfa/styleguide/pages_helper.rb
@@ -18,7 +18,7 @@ module Cfa
       def code_example_erb(partial_path)
         partial = lookup_context.find_template(partial_path, [], true)
 
-        filepath = partial.inspect
+        filepath = partial.identifier
         partial_contents = File.open(filepath, "r", &:read)
 
         partial_contents


### PR DESCRIPTION
Rails 6 no longer returns a path when inspecting an Action View template, which causes the style guide pages to break in Rails 6 apps. This change addresses that and restores access to the Honeycrisp pages.