### PR TITLE
Style disabled buttons directly via disabled property

### DIFF
--- a/app/assets/stylesheets/atoms/_buttons.scss
+++ b/app/assets/stylesheets/atoms/_buttons.scss
@@ -65,6 +65,7 @@
     }
 }
 
+&:disabled,
 .button--disabled {
   opacity: .5;
   cursor: not-allowed;

--- a/app/assets/stylesheets/atoms/_buttons.scss
+++ b/app/assets/stylesheets/atoms/_buttons.scss
@@ -65,8 +65,7 @@
     }
 }
 
-&:disabled,
-.button--disabled {
+.button:disabled, .button--disabled {
   opacity: .5;
   cursor: not-allowed;
 }


### PR DESCRIPTION
This allows styling a disabled button purely by adding the `disabled` property, instead of having to both add the `.button--disabled` _and_ the `disabled` property.