### PR TITLE
Add labels to form input examples

### DIFF
--- a/app/views/examples/atoms/_form_elements.html.erb
+++ b/app/views/examples/atoms/_form_elements.html.erb
@@ -1,34 +1,82 @@
 <form action="POST">
-  <label class="form-question" for="example_text">Form question, usually posed as a question?</label>
   <h3>Text input fields</h3>
-  <input type="text" class="text-input" placeholder="Text input" name="example_text">
-  <input type="text" class="text-input form-width--long" placeholder="Long" name="example_text">
-  <input type="text" class="text-input form-width--med" placeholder="Medium" name="example_text">
-  <input type="text" class="text-input form-width--short" placeholder="Short" name="example_text">
-  <input type="text" class="text-input form-width--name" placeholder="Name" name="example_text">
-  <input type="text" class="text-input form-width--zip" placeholder="ZIP" name="example_text">
-  <h3>Masked (auto-formatted) text input fields</h3>
-  <input type="tel" class="text-input form-width--phone phone-input" placeholder="Phone #" name="example_text" id="example_phone_input">
-  <input type="tel" class="text-input form-width--ssn ssn-input" placeholder="SSN" name="example_text" id="example_ssn_input">
-  <h3>Other input types</h3>
-  <label for="example_radio" class="radio-button">
-    <input type="radio" name="example_radio" id="example_radio">
-    Example radio button
-  </label>
-  <label for="example_checkbox" class="checkbox">
-    <input type="checkbox" name="example_checkbox" id="example_checkbox">
-    Example checkbox
-  </label>
-  <div class="select">
-    <select class="select__element" name="example_select" id="example_select">
-      <option selected disabled>Choose a selection</option>
-      <option value="1">Selection 1</option>
-      <option value="2">Selection 2</option>
-      <option value="2">Selection 3</option>
-    </select>
+
+  <div class="form-group">
+    <label class="form-question" for="apple_comment">What would you like to tell us about apples?</label>
+    <input type="text" class="text-input" name="apple_comment" id="apple_comment">
   </div>
 
-  <textarea name="example_textarea" class="textarea" id="" cols="30" rows="10"></textarea>
+  <div class="form-group">
+    <label class="form-question" for="favorite_apples">What are your favorite apples?</label>
+    <input type="text" class="text-input form-width--long" name="favorite_apples" id="favorite_apples">
+  </div>
+
+  <div class="form-group">
+    <label class="form-question" for="them_apples">How about them apples?</label>
+    <input type="text" class="text-input form-width--med" name="them_apples" id="them_apples">
+  </div>
+
+  <div class="form-group">
+    <label class="form-question" for="apple_word">What is one word to describe an apple?</label>
+    <input type="text" class="text-input form-width--short" name="apple_word" id="apple_word">
+  </div>
+
+  <div class="form-group">
+    <label class="form-question" for="name">What is your name?</label>
+    <input type="text" class="text-input form-width--name" name="name" id="name">
+  </div>
+
+  <div class="form-group">
+    <label class="form-question" for="zip">What is your ZIP code?</label>
+    <input type="text" class="text-input form-width--zip" name="zip" id="zip">
+  </div>
+
+  <h3>Masked (auto-formatted) text input fields</h3>
+
+  <div class="form-group">
+    <label class="form-question" for="phone">What is your phone number?</label>
+    <input type="tel" class="text-input form-width--phone phone-input" name="phone" id="phone">
+  </div>
+
+
+  <div class="form-group">
+    <label class="form-question" for="ssn">What is your Social Security Number?</label>
+    <input type="tel" class="text-input form-width--ssn ssn-input" name="ssn" id="ssn">
+  </div>
+
+  <h3>Other input types</h3>
+
+  <div class="form-group">
+    <label for="example_radio" class="radio-button">
+      <input type="radio" name="example_radio" id="example_radio">
+      Example radio button
+    </label>
+  </div>
+
+  <div class="form-group">
+    <label for="example_checkbox" class="checkbox">
+      <input type="checkbox" name="example_checkbox" id="example_checkbox">
+      Example checkbox
+    </label>
+  </div>
+
+  <div class="form-group">
+    <label for="apple_quality" class="form-question">What's your favorite apple quality?</label>
+    <div class="select">
+      <select class="select__element" name="apple_quality" id="apple_quality">
+        <option selected disabled>Choose a selection</option>
+        <option value="crisp">Crisp</option>
+        <option value="sweet">Sweet</option>
+        <option value="tart">Tart</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label for="apple_story" class="form-question">Can you tell us about the last time you ate an apple?</label>
+    <textarea name="apple_story" id="apple_story" class="textarea" id="" cols="30" rows="10"></textarea>
+  </div>
+
   <div class="file-upload">
     <input type="file" id="example_file_upload" name="example_file_upload" class="file-upload__input">
     <label class="button" for="example_file_upload" class="file-upload__label">Upload documents <i class="button__icon icon-file_upload"></i></label>

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -10,13 +10,6 @@ GENERAL_ACCESSIBILITY_SKIPS = [
   "region",
 ].freeze
 
-## Checks that aren't applicable to specific examples and can be ignored
-SPECIFIC_ACCESSIBILITY_SKIPS = {
-  "atoms/form_elements" => [
-    "label", # Example demonstrates various input atoms, not label+input molecule
-  ],
-}.freeze
-
 ## Examples with accessibility issues that must be fixed in the fullness of time
 FIXABLE_ACCESSIBILITY_EXAMPLES = [
   "form_builder/cfa_checkbox_set",
@@ -46,8 +39,7 @@ RSpec.describe "Acessibility", js: true do
 
         visit example_path
 
-        accessibility_skips = GENERAL_ACCESSIBILITY_SKIPS + SPECIFIC_ACCESSIBILITY_SKIPS.fetch(example, [])
-        expect(page).to be_accessible.skipping(*accessibility_skips)
+        expect(page).to be_accessible.skipping(*GENERAL_ACCESSIBILITY_SKIPS)
       end
     end
   end

--- a/spec/system/formatted_input_spec.rb
+++ b/spec/system/formatted_input_spec.rb
@@ -7,51 +7,51 @@ describe "Autoformatted input fields" do
 
   describe "SSN input fields" do
     it "can auto-format an SSN", js: true do
-      fill_in "example_ssn_input", with: "111223333"
+      fill_in "ssn", with: "111223333"
 
-      expect(page).to have_field("example_ssn_input", with: "111-22-3333")
+      expect(page).to have_field("ssn", with: "111-22-3333")
     end
 
     it "ignores non-numeric characters", js: true do
-      fill_in "example_ssn_input", with: "1a2s3d4"
+      fill_in "ssn", with: "1a2s3d4"
 
-      expect(page).to have_field("example_ssn_input", with: "123-4")
+      expect(page).to have_field("ssn", with: "123-4")
     end
 
     it "can handle backspace", js: true do
-      fill_in "example_ssn_input", with: "1112233"
-      find("#example_ssn_input").send_keys :backspace, :backspace
+      fill_in "ssn", with: "1112233"
+      find("#ssn").send_keys :backspace, :backspace
 
-      expect(page).to have_field("example_ssn_input", with: "111-22")
+      expect(page).to have_field("ssn", with: "111-22")
 
-      find("#example_ssn_input").send_keys "4", "5", :left, :left, :left, :left, "6"
+      find("#ssn").send_keys "4", "5", :left, :left, :left, :left, "6"
 
-      expect(page).to have_field("example_ssn_input", with: "111-26-245")
+      expect(page).to have_field("ssn", with: "111-26-245")
     end
   end
 
   describe "Phone input fields" do
     it "can auto-format a phone number", js: true do
-      fill_in "example_phone_input", with: "1112223333"
+      fill_in "phone", with: "1112223333"
 
-      expect(page).to have_field("example_phone_input", with: "(111) 222-3333")
+      expect(page).to have_field("phone", with: "(111) 222-3333")
     end
 
     it "ignores non-numeric characters", js: true do
-      fill_in "example_phone_input", with: "1a2s3d4"
+      fill_in "phone", with: "1a2s3d4"
 
-      expect(page).to have_field("example_phone_input", with: "(123) 4")
+      expect(page).to have_field("phone", with: "(123) 4")
     end
 
     it "can handle backspace", js: true do
-      fill_in "example_phone_input", with: "11122233"
-      find("#example_phone_input").send_keys :backspace, :backspace
+      fill_in "phone", with: "11122233"
+      find("#phone").send_keys :backspace, :backspace
 
-      expect(page).to have_field("example_phone_input", with: "(111) 222")
+      expect(page).to have_field("phone", with: "(111) 222")
 
-      find("#example_phone_input").send_keys "4", "5", :left, :left, :left, :left, "6"
+      find("#phone").send_keys "4", "5", :left, :left, :left, :left, "6"
 
-      expect(page).to have_field("example_phone_input", with: "(111) 226-245")
+      expect(page).to have_field("phone", with: "(111) 226-245")
     end
   end
 end


### PR DESCRIPTION
This adds labels to all the form input examples so that we can pass accessibility checks and set a better example.