### PR TITLE
Fix - Readd incrementer.init()

### DIFF
--- a/app/assets/javascripts/cfa_styleguide_main.js
+++ b/app/assets/javascripts/cfa_styleguide_main.js
@@ -319,4 +319,5 @@ $(document).ready(function () {
   accordion.init();
   selectBodyBottomMargin.init();
   numericFormatters.init();
+  incrementer.init();
 });


### PR DESCRIPTION
This looks like it was removed with this change. Not sure if it's intended to be deprecated or not
https://github.com/codeforamerica/honeycrisp-gem/pull/3

Component is currently not working in the styleguide
![Screen Shot 2021-01-04 at 4 10 40 PM](https://user-images.githubusercontent.com/72890349/103594464-9f120880-4ead-11eb-836e-d50b38254d66.png)
