### PR TITLE
vendorize `neat` 1.8.0 to relax dependency on old thor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       autoprefixer-rails
       bourbon
       jquery-rails
-      neat (~> 1.8.0)
+      sass
 
 GEM
   remote: https://rubygems.org/
@@ -130,9 +130,6 @@ GEM
     minitest (5.14.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    neat (1.8.0)
-      sass (>= 3.3)
-      thor (~> 0.19)
     nio4r (2.5.4)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)

--- a/app/assets/stylesheets/cfa_styleguide_main.scss
+++ b/app/assets/stylesheets/cfa_styleguide_main.scss
@@ -1,6 +1,6 @@
 /* Vendor */
 @import 'bourbon';
-@import 'neat';
+@import 'neat/neat';
 @import "normalize";
 
 /* Variables */

--- a/cfa-styleguide.gemspec
+++ b/cfa-styleguide.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "autoprefixer-rails"
   spec.add_runtime_dependency "bourbon"
   spec.add_runtime_dependency "jquery-rails"
-  spec.add_runtime_dependency "neat", "~> 1.8.0"
+  spec.add_runtime_dependency "sass"
   spec.add_development_dependency "axe-matchers", "~> 2.2"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "capybara"

--- a/lib/tasks/distribution.rb
+++ b/lib/tasks/distribution.rb
@@ -91,8 +91,7 @@ class Distribution
   end
 
   def install_dependencies
-    `bourbon install --path dist/vendor && neat install`
-    FileUtils.move("#{Dir.pwd}/neat", "#{DIST_PATH}/vendor")
+    `bourbon install --path dist/vendor`
 
     Sprockets.register_compressor(
       "application/javascript",

--- a/vendor/assets/stylesheets/neat/_neat-helpers.scss
+++ b/vendor/assets/stylesheets/neat/_neat-helpers.scss
@@ -1,0 +1,11 @@
+// Mixins
+@import "mixins/clearfix";
+
+// Functions
+@import "functions/private";
+@import "functions/new-breakpoint";
+
+// Settings
+@import "settings/grid";
+@import "settings/visual-grid";
+@import "settings/disable-warnings";

--- a/vendor/assets/stylesheets/neat/_neat.scss
+++ b/vendor/assets/stylesheets/neat/_neat.scss
@@ -1,0 +1,23 @@
+// Neat 1.8.0
+// http://neat.bourbon.io
+// Copyright 2012-2015 thoughtbot, inc.
+// MIT License
+
+// Helpers
+@import "neat-helpers";
+
+// Grid
+@import "grid/private";
+@import "grid/box-sizing";
+@import "grid/omega";
+@import "grid/outer-container";
+@import "grid/span-columns";
+@import "grid/row";
+@import "grid/shift";
+@import "grid/pad";
+@import "grid/fill-parent";
+@import "grid/media";
+@import "grid/to-deprecate";
+@import "grid/visual-grid";
+@import "grid/display-context";
+@import "grid/direction-context";

--- a/vendor/assets/stylesheets/neat/functions/_new-breakpoint.scss
+++ b/vendor/assets/stylesheets/neat/functions/_new-breakpoint.scss
@@ -1,0 +1,49 @@
+@charset "UTF-8";
+
+/// Returns a media context (media query / grid context) that can be stored in a variable and passed to `media()` as a single-keyword argument. Media contexts defined using `new-breakpoint` are used by the visual grid, as long as they are defined before importing Neat.
+///
+/// @param {List} $query
+///   A list of media query features and values. Each `$feature` should have a corresponding `$value`.
+///
+///   If there is only a single `$value` in `$query`, `$default-feature` is going to be used.
+///
+///   The number of total columns in the grid can be set by passing `$columns` at the end of the list (overrides `$total-columns`). For a list of valid values for `$feature`, click [here](http://www.w3.org/TR/css3-mediaqueries/#media1).
+///
+/// @param {Number (unitless)} $total-columns [$grid-columns]
+///   - Number of columns to use in the new grid context. Can be set as a shorthand in the first parameter.
+///
+/// @example scss - Usage
+///   $mobile: new-breakpoint(max-width 480px 4);
+///
+///   .element {
+///     @include media($mobile) {
+///       @include span-columns(4);
+///     }
+///   }
+///
+/// @example css - CSS Output
+///   @media screen and (max-width: 480px) {
+///     .element {
+///       display: block;
+///       float: left;
+///       margin-right: 7.42297%;
+///       width: 100%;
+///     }
+///     .element:last-child {
+///       margin-right: 0;
+///     }
+///   }
+
+@function new-breakpoint($query: $feature $value $columns, $total-columns: $grid-columns) {
+  @if length($query) == 1 {
+    $query: $default-feature nth($query, 1) $total-columns;
+  } @else if is-even(length($query)) {
+    $query: append($query, $total-columns);
+  }
+
+  @if is-not(belongs-to($query, $visual-grid-breakpoints)) {
+    $visual-grid-breakpoints: append($visual-grid-breakpoints, $query, comma) !global;
+  }
+
+  @return $query;
+}

--- a/vendor/assets/stylesheets/neat/functions/_private.scss
+++ b/vendor/assets/stylesheets/neat/functions/_private.scss
@@ -1,0 +1,114 @@
+// Not function for Libsass compatibility
+// https://github.com/sass/libsass/issues/368
+@function is-not($value) {
+  @return if($value, false, true);
+}
+
+// Checks if a number is even
+@function is-even($int) {
+  @return $int % 2 == 0;
+}
+
+// Checks if an element belongs to a list or not
+@function belongs-to($tested-item, $list) {
+  @return is-not(not-belongs-to($tested-item, $list));
+}
+
+@function not-belongs-to($tested-item, $list) {
+  @return is-not(index($list, $tested-item));
+}
+
+// Contains display value
+@function contains-display-value($query) {
+  @return belongs-to(table, $query)
+       or belongs-to(block, $query)
+       or belongs-to(inline-block, $query)
+       or belongs-to(inline, $query);
+}
+
+// Parses the first argument of span-columns()
+@function container-span($span: $span) {
+  @if length($span) == 3 {
+    $container-columns: nth($span, 3);
+    @return $container-columns;
+  } @else if length($span) == 2 {
+    $container-columns: nth($span, 2);
+    @return $container-columns;
+  }
+
+  @return $grid-columns;
+}
+
+@function container-shift($shift: $shift) {
+  $parent-columns: $grid-columns !default !global;
+
+  @if length($shift) == 3 {
+    $container-columns: nth($shift, 3);
+    @return $container-columns;
+  } @else if length($shift) == 2 {
+    $container-columns: nth($shift, 2);
+    @return $container-columns;
+  }
+
+  @return $parent-columns;
+}
+
+// Generates a striped background
+@function gradient-stops($grid-columns, $color: $visual-grid-color) {
+  $transparent: transparent;
+
+  $column-width: flex-grid(1, $grid-columns);
+  $gutter-width: flex-gutter($grid-columns);
+  $column-offset: $column-width;
+
+  $values: ($transparent 0, $color 0);
+
+  @for $i from 1 to $grid-columns*2 {
+    @if is-even($i) {
+      $values: append($values, $transparent $column-offset, comma);
+      $values: append($values, $color $column-offset, comma);
+      $column-offset: $column-offset + $column-width;
+    } @else {
+      $values: append($values, $color $column-offset, comma);
+      $values: append($values, $transparent $column-offset, comma);
+      $column-offset: $column-offset + $gutter-width;
+    }
+  }
+
+  @return $values;
+}
+
+// Layout direction
+@function get-direction($layout, $default) {
+  $direction: null;
+
+  @if to-upper-case($layout) == "LTR" or to-upper-case($layout) == "RTL" {
+    $direction: direction-from-layout($layout);
+  } @else {
+    $direction: direction-from-layout($default);
+  }
+
+  @return $direction;
+}
+
+@function direction-from-layout($layout) {
+  $direction: null;
+
+  @if to-upper-case($layout) == "LTR" {
+    $direction: right;
+  } @else {
+    $direction: left;
+  }
+
+  @return $direction;
+}
+
+@function get-opposite-direction($direction) {
+  $opposite-direction: left;
+
+  @if $direction == "left" {
+    $opposite-direction: right;
+  }
+
+  @return $opposite-direction;
+}

--- a/vendor/assets/stylesheets/neat/grid/_box-sizing.scss
+++ b/vendor/assets/stylesheets/neat/grid/_box-sizing.scss
@@ -1,0 +1,15 @@
+@charset "UTF-8";
+
+@if $border-box-sizing == true {
+  html { // http://bit.ly/1qk2tVR
+    box-sizing: border-box;
+  }
+
+  * {
+    &,
+    &::after,
+    &::before {
+      box-sizing: inherit;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/neat/grid/_direction-context.scss
+++ b/vendor/assets/stylesheets/neat/grid/_direction-context.scss
@@ -1,0 +1,33 @@
+@charset "UTF-8";
+
+/// Changes the direction property used by other mixins called in the code block argument.
+///
+/// @param {String} $direction [left-to-right]
+///   Layout direction to be used within the block. Can be `left-to-right` or `right-to-left`.
+///
+/// @example scss - Usage
+///   @include direction-context(right-to-left) {
+///    .right-to-left-block {
+///      @include span-columns(6);
+///     }
+///   }
+///
+/// @example css - CSS Output
+///   .right-to-left-block {
+///     float: right;
+///      ...
+///   }
+
+@mixin direction-context($direction: left-to-right) {
+  $scope-direction: $layout-direction;
+
+  @if to-lower-case($direction) == "left-to-right" {
+    $layout-direction: LTR !global;
+  } @else if to-lower-case($direction) == "right-to-left" {
+    $layout-direction: RTL !global;
+  }
+
+  @content;
+
+  $layout-direction: $scope-direction !global;
+}

--- a/vendor/assets/stylesheets/neat/grid/_display-context.scss
+++ b/vendor/assets/stylesheets/neat/grid/_display-context.scss
@@ -1,0 +1,28 @@
+@charset "UTF-8";
+
+/// Changes the display property used by other mixins called in the code block argument.
+///
+/// @param {String} $display [block]
+///   Display value to be used within the block. Can be `table` or `block`.
+///
+/// @example scss
+///   @include display-context(table) {
+///    .display-table {
+///      @include span-columns(6);
+///     }
+///   }
+///
+/// @example css
+///   .display-table {
+///      display: table-cell;
+///      ...
+///   }
+
+@mixin display-context($display: block) {
+  $scope-display: $container-display-table;
+  $container-display-table: $display == table !global;
+
+  @content;
+
+  $container-display-table: $scope-display !global;
+}

--- a/vendor/assets/stylesheets/neat/grid/_fill-parent.scss
+++ b/vendor/assets/stylesheets/neat/grid/_fill-parent.scss
@@ -1,0 +1,22 @@
+@charset "UTF-8";
+
+/// Forces the element to fill its parent container.
+///
+/// @example scss - Usage
+///   .element {
+///     @include fill-parent;
+///   }
+///
+/// @example css - CSS Output
+///   .element {
+///     width: 100%;
+///     box-sizing: border-box;
+///   }
+
+@mixin fill-parent() {
+  width: 100%;
+
+  @if $border-box-sizing == false {
+    box-sizing: border-box;
+  }
+}

--- a/vendor/assets/stylesheets/neat/grid/_media.scss
+++ b/vendor/assets/stylesheets/neat/grid/_media.scss
@@ -1,0 +1,92 @@
+@charset "UTF-8";
+
+/// Outputs a media-query block with an optional grid context (the total number of columns used in the grid).
+///
+/// @param {List} $query
+///   A list of media query features and values, where each `$feature` should have a corresponding `$value`.
+///   For a list of valid values for `$feature`, click [here](http://www.w3.org/TR/css3-mediaqueries/#media1).
+///
+///   If there is only a single `$value` in `$query`, `$default-feature` is going to be used.
+///
+///   The number of total columns in the grid can be set by passing `$columns` at the end of the list (overrides `$total-columns`).
+///
+///
+/// @param {Number (unitless)} $total-columns [$grid-columns]
+///   - Number of columns to use in the new grid context. Can be set as a shorthand in the first parameter.
+///
+/// @example scss - Usage
+///   .responsive-element {
+///      @include media(769px) {
+///        @include span-columns(6);
+///      }
+///   }
+///
+///  .new-context-element {
+///    @include media(min-width 320px max-width 480px, 6) {
+///      @include span-columns(6);
+///    }
+///  }
+///
+/// @example css - CSS Output
+///  @media screen and (min-width: 769px) {
+///    .responsive-element {
+///      display: block;
+///      float: left;
+///      margin-right: 2.35765%;
+///      width: 48.82117%;
+///    }
+///
+///    .responsive-element:last-child {
+///      margin-right: 0;
+///    }
+///  }
+///
+///  @media screen and (min-width: 320px) and (max-width: 480px) {
+///    .new-context-element {
+///      display: block;
+///      float: left;
+///      margin-right: 4.82916%;
+///      width: 100%;
+///    }
+///
+///    .new-context-element:last-child {
+///      margin-right: 0;
+///    }
+///  }
+
+@mixin media($query: $feature $value $columns, $total-columns: $grid-columns) {
+  @if length($query) == 1 {
+    @media screen and ($default-feature: nth($query, 1)) {
+      $default-grid-columns: $grid-columns;
+      $grid-columns: $total-columns !global;
+      @content;
+      $grid-columns: $default-grid-columns !global;
+    }
+  } @else {
+    $loop-to: length($query);
+    $media-query: "screen and ";
+    $default-grid-columns: $grid-columns;
+    $grid-columns: $total-columns !global;
+
+    @if is-not(is-even(length($query))) {
+      $grid-columns: nth($query, $loop-to) !global;
+      $loop-to: $loop-to - 1;
+    }
+
+    $i: 1;
+    @while $i <= $loop-to {
+      $media-query: $media-query + "(" + nth($query, $i) + ": " + nth($query, $i + 1) + ") ";
+
+      @if ($i + 1) != $loop-to {
+        $media-query: $media-query + "and ";
+      }
+
+      $i: $i + 2;
+    }
+
+    @media #{$media-query} {
+      @content;
+      $grid-columns: $default-grid-columns !global;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/neat/grid/_omega.scss
+++ b/vendor/assets/stylesheets/neat/grid/_omega.scss
@@ -1,0 +1,87 @@
+@charset "UTF-8";
+
+/// Removes the element's gutter margin, regardless of its position in the grid hierarchy or display property. It can target a specific element, or every `nth-child` occurrence. Works only with `block` layouts.
+///
+/// @param {List} $query [block]
+///   List of arguments. Supported arguments are `nth-child` selectors (targets a specific pseudo element) and `auto` (targets `last-child`).
+///
+///   When passed an `nth-child` argument of type `*n` with `block` display, the omega mixin automatically adds a clear to the `*n+1` th element. Note that composite arguments such as `2n+1` do not support this feature.
+///
+///   **Deprecation warning**: The omega mixin will no longer take a `$direction` argument. To change the layout direction, use `row($direction)` or set `$default-layout-direction` instead.
+///
+/// @example scss - Usage
+///   .element {
+///     @include omega;
+///   }
+///
+///   .nth-element {
+///     @include omega(4n);
+///   }
+///
+/// @example css - CSS Output
+///   .element {
+///     margin-right: 0;
+///   }
+///
+///   .nth-element:nth-child(4n) {
+///     margin-right: 0;
+///   }
+///
+///   .nth-element:nth-child(4n+1) {
+///     clear: left;
+///   }
+
+@mixin omega($query: block, $direction: default) {
+  $table: belongs-to(table, $query);
+  $auto: belongs-to(auto, $query);
+
+  @if $direction != default {
+    @include -neat-warn("The omega mixin will no longer take a $direction argument. To change the layout direction, use the direction(){...} mixin.");
+  } @else {
+    $direction: get-direction($layout-direction, $default-layout-direction);
+  }
+
+  @if $table {
+    @include -neat-warn("The omega mixin no longer removes padding in table layouts.");
+  }
+
+  @if length($query) == 1 {
+    @if $auto {
+      &:last-child {
+        margin-#{$direction}: 0;
+      }
+    }
+
+    @else if contains-display-value($query) and $table == false {
+      margin-#{$direction}: 0;
+    }
+
+    @else {
+      @include nth-child($query, $direction);
+    }
+  } @else if length($query) == 2 {
+    @if $auto {
+      &:last-child {
+        margin-#{$direction}: 0;
+      }
+    } @else {
+      @include nth-child(nth($query, 1), $direction);
+    }
+  } @else {
+    @include -neat-warn("Too many arguments passed to the omega() mixin.");
+  }
+}
+
+@mixin nth-child($query, $direction) {
+  $opposite-direction: get-opposite-direction($direction);
+
+  &:nth-child(#{$query}) {
+    margin-#{$direction}: 0;
+  }
+
+  @if type-of($query) == number and unit($query) == "n" {
+    &:nth-child(#{$query}+1) {
+      clear: $opposite-direction;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/neat/grid/_outer-container.scss
+++ b/vendor/assets/stylesheets/neat/grid/_outer-container.scss
@@ -1,0 +1,34 @@
+@charset "UTF-8";
+
+/// Makes an element a outer container by centering it in the viewport, clearing its floats, and setting its `max-width`.
+/// Although optional, using `outer-container` is recommended. The mixin can be called on more than one element per page, as long as they are not nested.
+///
+/// @param {Number [unit]} $local-max-width [$max-width]
+///   Max width to be applied to the element. Can be a percentage or a measure.
+///
+/// @example scss - Usage
+///   .element {
+///     @include outer-container(100%);
+///   }
+///
+/// @example css - CSS Output
+///   .element {
+///     max-width: 100%;
+///     margin-left: auto;
+///     margin-right: auto;
+///   }
+///
+///   .element::after {
+///     clear: both;
+///     content: "";
+///     display: table;
+///   }
+
+@mixin outer-container($local-max-width: $max-width) {
+  @include clearfix;
+  max-width: $local-max-width;
+  margin: {
+    left: auto;
+    right: auto;
+  }
+}

--- a/vendor/assets/stylesheets/neat/grid/_pad.scss
+++ b/vendor/assets/stylesheets/neat/grid/_pad.scss
@@ -1,0 +1,25 @@
+@charset "UTF-8";
+
+/// Adds padding to the element.
+///
+/// @param {List} $padding [flex-gutter()]
+///   A list of padding value(s) to use. Passing `default` in the list will result in using the gutter width as a padding value.
+///
+/// @example scss - Usage
+///   .element {
+///     @include pad(30px -20px 10px default);
+///   }
+///
+/// @example css - CSS Output
+///   .element {
+///     padding: 30px -20px 10px 2.35765%;
+///   }
+
+@mixin pad($padding: flex-gutter()) {
+  $padding-list: null;
+  @each $value in $padding {
+    $value: if($value == 'default', flex-gutter(), $value);
+    $padding-list: join($padding-list, $value);
+  }
+  padding: $padding-list;
+}

--- a/vendor/assets/stylesheets/neat/grid/_private.scss
+++ b/vendor/assets/stylesheets/neat/grid/_private.scss
@@ -1,0 +1,35 @@
+$parent-columns: $grid-columns !default;
+$fg-column: $column;
+$fg-gutter: $gutter;
+$fg-max-columns: $grid-columns;
+$container-display-table: false !default;
+$layout-direction: LTR !default;
+
+@function flex-grid($columns, $container-columns: $fg-max-columns) {
+  $width: $columns * $fg-column + ($columns - 1) * $fg-gutter;
+  $container-width: $container-columns * $fg-column + ($container-columns - 1) * $fg-gutter;
+  @return percentage($width / $container-width);
+}
+
+@function flex-gutter($container-columns: $fg-max-columns, $gutter: $fg-gutter) {
+  $container-width: $container-columns * $fg-column + ($container-columns - 1) * $fg-gutter;
+  @return percentage($gutter / $container-width);
+}
+
+@function grid-width($n) {
+  @return $n * $gw-column + ($n - 1) * $gw-gutter;
+}
+
+@function get-parent-columns($columns) {
+  @if $columns != $grid-columns {
+    $parent-columns: $columns !global;
+  } @else {
+    $parent-columns: $grid-columns !global;
+  }
+
+  @return $parent-columns;
+}
+
+@function is-display-table($container-is-display-table, $display) {
+  @return $container-is-display-table == true or $display == table;
+}

--- a/vendor/assets/stylesheets/neat/grid/_row.scss
+++ b/vendor/assets/stylesheets/neat/grid/_row.scss
@@ -1,0 +1,52 @@
+@charset "UTF-8";
+
+/// Designates the element as a row of columns in the grid layout. It clears the floats on the element and sets its display property. Rows can't be nested, but there can be more than one row element—with different display properties—per layout.
+///
+/// @param {String} $display [default]
+///  Sets the display property of the element and the display context that will be used by its children. Can be `block` or `table`.
+///
+/// @param {String} $direction [$default-layout-direction]
+///  Sets the layout direction. Can be `LTR` (left-to-right) or `RTL` (right-to-left).
+///
+/// @example scss - Usage
+///  .element {
+///    @include row();
+///  }
+///
+/// @example css - CSS Output
+///  .element {
+///    *zoom: 1;
+///    display: block;
+///  }
+///
+/// .element:before, .element:after {
+///   content: " ";
+///   display: table;
+/// }
+///
+/// .element:after {
+///   clear: both;
+/// }
+
+@mixin row($display: default, $direction: $default-layout-direction) {
+  @if $direction != $default-layout-direction {
+    @include -neat-warn("The $direction argument will be deprecated in future versions in favor of the direction(){...} mixin.");
+  }
+
+  $layout-direction: $direction !global;
+
+  @if $display != default {
+    @include -neat-warn("The $display argument will be deprecated in future versions in favor of the display(){...} mixin.");
+  }
+
+  @if $display == table {
+    display: table;
+    @include fill-parent;
+    table-layout: fixed;
+    $container-display-table: true !global;
+  } @else {
+    @include clearfix;
+    display: block;
+    $container-display-table: false !global;
+  }
+}

--- a/vendor/assets/stylesheets/neat/grid/_shift.scss
+++ b/vendor/assets/stylesheets/neat/grid/_shift.scss
@@ -1,0 +1,50 @@
+@charset "UTF-8";
+
+/// Translates an element horizontally by a number of columns. Positive arguments shift the element to the active layout direction, while negative ones shift it to the opposite direction.
+///
+/// @param {Number (unitless)} $n-columns [1]
+///   Number of columns by which the element shifts.
+///
+/// @example scss - Usage
+///   .element {
+///     @include shift(-3);
+///   }
+///
+/// @example css - CSS output
+///   .element {
+///     margin-left: -25.58941%;
+///   }
+
+@mixin shift($n-columns: 1) {
+  @include shift-in-context($n-columns);
+}
+
+/// Translates an element horizontally by a number of columns, in a specific nesting context.
+///
+/// @param {List} $shift
+///   A list containing the number of columns to shift (`$columns`) and the number of columns of the parent element (`$container-columns`).
+///
+///   The two values can be separated with any string such as `of`, `/`, etc.
+///
+/// @example scss - Usage
+///   .element {
+///     @include shift(-3 of 6);
+///   }
+///
+/// @example css - CSS output
+///   .element {
+///     margin-left: -52.41458%;
+///   }
+
+@mixin shift-in-context($shift: $columns of $container-columns) {
+  $n-columns: nth($shift, 1);
+  $parent-columns: container-shift($shift) !global;
+
+  $direction: get-direction($layout-direction, $default-layout-direction);
+  $opposite-direction: get-opposite-direction($direction);
+
+  margin-#{$opposite-direction}: $n-columns * flex-grid(1, $parent-columns) + $n-columns * flex-gutter($parent-columns);
+
+  // Reset nesting context
+  $parent-columns: $grid-columns !global;
+}

--- a/vendor/assets/stylesheets/neat/grid/_span-columns.scss
+++ b/vendor/assets/stylesheets/neat/grid/_span-columns.scss
@@ -1,0 +1,94 @@
+@charset "UTF-8";
+
+/// Specifies the number of columns an element should span. If the selector is nested the number of columns of its parent element should be passed as an argument as well.
+///
+/// @param {List} $span
+///   A list containing `$columns`, the unitless number of columns the element spans (required), and `$container-columns`, the number of columns the parent element spans (optional).
+///
+///   If only one value is passed, it is assumed that it's `$columns` and that that `$container-columns` is equal to `$grid-columns`, the total number of columns in the grid.
+///
+///   The values can be separated with any string such as `of`, `/`, etc.
+///
+///   `$columns` also accepts decimals for when it's necessary to break out of the standard grid. E.g. Passing `2.4` in a standard 12 column grid will divide the row into 5 columns.
+///
+/// @param {String} $display [block]
+///   Sets the display property of the element. By default it sets the display property of the element to `block`.
+///
+///   If passed `block-collapse`, it also removes the margin gutter by adding it to the element width.
+///
+///   If passed `table`, it sets the display property to `table-cell` and calculates the width of the element without taking gutters into consideration. The result does not align with the block-based grid.
+///
+/// @example scss - Usage
+///   .element {
+///     @include span-columns(6);
+///
+///    .nested-element {
+///      @include span-columns(2 of 6);
+///    }
+///  }
+///
+/// @example css - CSS Output
+///   .element {
+///     display: block;
+///     float: left;
+///     margin-right: 2.35765%;
+///     width: 48.82117%;
+///   }
+///
+///   .element:last-child {
+///     margin-right: 0;
+///   }
+///
+///   .element .nested-element {
+///     display: block;
+///     float: left;
+///     margin-right: 4.82916%;
+///     width: 30.11389%;
+///   }
+///
+///   .element .nested-element:last-child {
+///     margin-right: 0;
+///   }
+
+@mixin span-columns($span: $columns of $container-columns, $display: block) {
+  $columns: nth($span, 1);
+  $container-columns: container-span($span);
+
+  $parent-columns: get-parent-columns($container-columns) !global;
+
+  $direction: get-direction($layout-direction, $default-layout-direction);
+  $opposite-direction: get-opposite-direction($direction);
+
+  $display-table: is-display-table($container-display-table, $display);
+
+  @if $display-table  {
+    display: table-cell;
+    width: percentage($columns / $container-columns);
+  } @else {
+    float: #{$opposite-direction};
+
+    @if $display != no-display {
+      display: block;
+    }
+
+    @if $display == collapse {
+      @include -neat-warn("The 'collapse' argument will be deprecated. Use 'block-collapse' instead.");
+    }
+
+    @if $display == collapse or $display == block-collapse {
+      width: flex-grid($columns, $container-columns) + flex-gutter($container-columns);
+
+      &:last-child {
+        width: flex-grid($columns, $container-columns);
+      }
+
+    } @else {
+      margin-#{$direction}: flex-gutter($container-columns);
+      width: flex-grid($columns, $container-columns);
+
+      &:last-child {
+        margin-#{$direction}: 0;
+      }
+    }
+  }
+}

--- a/vendor/assets/stylesheets/neat/grid/_to-deprecate.scss
+++ b/vendor/assets/stylesheets/neat/grid/_to-deprecate.scss
@@ -1,0 +1,97 @@
+@charset "UTF-8";
+
+@mixin breakpoint($query:$feature $value $columns, $total-columns: $grid-columns) {
+  @include -neat-warn("The breakpoint() mixin was renamed to media() in Neat 1.0. Please update your project with the new syntax before the next version bump.");
+
+  @if length($query) == 1 {
+    @media screen and ($default-feature: nth($query, 1)) {
+      $default-grid-columns: $grid-columns;
+      $grid-columns: $total-columns;
+      @content;
+      $grid-columns: $default-grid-columns;
+    }
+  } @else if length($query) == 2 {
+    @media screen and (nth($query, 1): nth($query, 2)) {
+      $default-grid-columns: $grid-columns;
+      $grid-columns: $total-columns;
+      @content;
+      $grid-columns: $default-grid-columns;
+    }
+  } @else if length($query) == 3 {
+    @media screen and (nth($query, 1): nth($query, 2)) {
+      $default-grid-columns: $grid-columns;
+      $grid-columns: nth($query, 3);
+      @content;
+      $grid-columns: $default-grid-columns;
+    }
+  } @else if length($query) == 4 {
+    @media screen and (nth($query, 1): nth($query, 2)) and (nth($query, 3): nth($query, 4)) {
+      $default-grid-columns: $grid-columns;
+      $grid-columns: $total-columns;
+      @content;
+      $grid-columns: $default-grid-columns;
+    }
+  } @else if length($query) == 5 {
+    @media screen and (nth($query, 1): nth($query, 2)) and (nth($query, 3): nth($query, 4)) {
+      $default-grid-columns: $grid-columns;
+      $grid-columns: nth($query, 5);
+      @content;
+      $grid-columns: $default-grid-columns;
+    }
+  } @else {
+    @include -neat-warn("Wrong number of arguments for breakpoint(). Read the documentation for more details.");
+  }
+}
+
+@mixin nth-omega($nth, $display: block, $direction: default) {
+  @include -neat-warn("The nth-omega() mixin is deprecated. Please use omega() instead.");
+  @include omega($nth $display, $direction);
+}
+
+/// Resets the active display property to `block`. Particularly useful when changing the display property in a single row.
+///
+/// @example scss - Usage
+///   .element {
+///     @include row(table);
+///     // Context changed to table display
+///   }
+///
+///   @include reset-display;
+///   // Context is reset to block display
+
+@mixin reset-display {
+  $container-display-table: false !global;
+  @include -neat-warn("Resetting $display will be deprecated in future versions in favor of the display(){...} mixin.");
+}
+
+/// Resets the active layout direction to the default value set in `$default-layout-direction`. Particularly useful when changing the layout direction in a single row.
+///
+/// @example scss - Usage
+///   .element {
+///     @include row($direction: RTL);
+///     // Context changed to right-to-left
+///   }
+///
+///   @include reset-layout-direction;
+///   // Context is reset to left-to-right
+
+@mixin reset-layout-direction {
+  $layout-direction: $default-layout-direction !global;
+  @include -neat-warn("Resetting $direction will be deprecated in future versions in favor of the direction(){...} mixin.");
+}
+
+/// Resets both the active layout direction and the active display property.
+///
+/// @example scss - Usage
+///   .element {
+///     @include row(table, RTL);
+///     // Context changed to table table and right-to-left
+///   }
+///
+///   @include reset-all;
+///   // Context is reset to block display and left-to-right
+
+@mixin reset-all {
+  @include reset-display;
+  @include reset-layout-direction;
+}

--- a/vendor/assets/stylesheets/neat/grid/_visual-grid.scss
+++ b/vendor/assets/stylesheets/neat/grid/_visual-grid.scss
@@ -1,0 +1,42 @@
+@charset "UTF-8";
+
+@mixin grid-column-gradient($values...) {
+  background-image: -webkit-linear-gradient(left, $values);
+  background-image: -moz-linear-gradient(left, $values);
+  background-image: -ms-linear-gradient(left, $values);
+  background-image: -o-linear-gradient(left, $values);
+  background-image: unquote("linear-gradient(to left, #{$values})");
+}
+
+@if $visual-grid == true or $visual-grid == yes {
+  body:before {
+    @include grid-column-gradient(gradient-stops($grid-columns));
+    content: "";
+    display: inline-block;
+    height: 100%;
+    left: 0;
+    margin: 0 auto;
+    max-width: $max-width;
+    opacity: $visual-grid-opacity;
+    pointer-events: none;
+    position: fixed;
+    right: 0;
+    width: 100%;
+
+    @if $visual-grid-index == back {
+      z-index: -1;
+    }
+
+    @else if $visual-grid-index == front {
+      z-index: 9999;
+    }
+
+    @each $breakpoint in $visual-grid-breakpoints {
+      @if $breakpoint {
+        @include media($breakpoint) {
+          @include grid-column-gradient(gradient-stops($grid-columns));
+        }
+      }
+    }
+  }
+}

--- a/vendor/assets/stylesheets/neat/mixins/_clearfix.scss
+++ b/vendor/assets/stylesheets/neat/mixins/_clearfix.scss
@@ -1,0 +1,25 @@
+@charset "UTF-8";
+
+/// Provides an easy way to include a clearfix for containing floats.
+///
+/// @link http://goo.gl/yP5hiZ
+///
+/// @example scss
+///   .element {
+///     @include clearfix;
+///   }
+///
+/// @example css
+///   .element::after {
+///     clear: both;
+///     content: "";
+///     display: block;
+///   }
+
+@mixin clearfix {
+  &::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}

--- a/vendor/assets/stylesheets/neat/settings/_disable-warnings.scss
+++ b/vendor/assets/stylesheets/neat/settings/_disable-warnings.scss
@@ -1,0 +1,13 @@
+@charset "UTF-8";
+
+/// Disable all deprecation warnings. Defaults to `false`. Set with a `!global` flag.
+///
+/// @type Bool
+
+$disable-warnings: false !default;
+
+@mixin -neat-warn($message) {
+  @if $disable-warnings == false {
+    @warn "#{$message}";
+  }
+}

--- a/vendor/assets/stylesheets/neat/settings/_grid.scss
+++ b/vendor/assets/stylesheets/neat/settings/_grid.scss
@@ -1,0 +1,51 @@
+@charset "UTF-8";
+
+/// Sets the relative width of a single grid column. The unit used should be the same one used to define `$gutter`. Set with a `!global` flag.
+///
+/// @type Number (Unit)
+
+$column: 4.2358em !default;
+
+/// Sets the relative width of a single grid gutter. The unit used should be the same one used to define `$column`. Set with the `!global` flag.
+///
+/// @type Number (Unit)
+
+$gutter: 1.618em !default;
+
+/// Sets the total number of columns in the grid. Its value can be overridden inside a media query using the `media()` mixin. Set with the `!global` flag.
+///
+/// @type Number (Unitless)
+
+$grid-columns: 12 !default;
+
+/// Sets the max-width property of the element that includes `outer-container()`. Set with the `!global` flag.
+///
+/// @type Number (Unit)
+///
+$max-width: 1200px !default;
+
+/// When set to true, it sets the box-sizing property of all elements to `border-box`. Set with a `!global` flag.
+///
+/// @type Bool
+///
+/// @example css - CSS Output
+///   html {
+///     box-sizing: border-box; }
+///
+///   *, *::after, *::before {
+///     box-sizing: inherit;
+///   }
+
+$border-box-sizing: true !default;
+
+/// Sets the default [media feature](http://www.w3.org/TR/css3-mediaqueries/#media) that `media()` and `new-breakpoint()` revert to when only a breakpoint value is passed. Set with a `!global` flag.
+///
+/// @type String
+
+$default-feature: min-width; // Default @media feature for the breakpoint() mixin
+
+///Sets the default layout direction of the grid. Can be `LTR` or `RTL`. Set with a `!global` flag.
+///
+///@type String
+
+$default-layout-direction: LTR !default;

--- a/vendor/assets/stylesheets/neat/settings/_visual-grid.scss
+++ b/vendor/assets/stylesheets/neat/settings/_visual-grid.scss
@@ -1,0 +1,27 @@
+@charset "UTF-8";
+
+/// Displays the visual grid when set to true. The overlaid grid may be few pixels off depending on the browser's rendering engine and pixel rounding algorithm. Set with the `!global` flag.
+///
+/// @type Bool
+
+$visual-grid: false !default;
+
+/// Sets the visual grid color. Set with `!global` flag.
+///
+/// @type Color
+
+$visual-grid-color: #eee !default;
+
+/// Sets the `z-index` property of the visual grid. Can be `back` (behind content) or `front` (in front of content). Set with `!global` flag.
+///
+/// @type String
+
+$visual-grid-index: back !default;
+
+/// Sets the opacity property of the visual grid. Set with `!global` flag.
+///
+/// @type Number (unitless)
+
+$visual-grid-opacity: 0.4 !default;
+
+$visual-grid-breakpoints: () !default;


### PR DESCRIPTION
to use the latest Rails, we need to be able to use thor 1.x,
and `neat` locked it to an old version.

Fixes #232