### PR TITLE
Updating honeycrisp compact styles 

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -1,6 +1,6 @@
 .honeycrisp-compact {
-  font-size: $font-size-19;
-  line-height: $s19;
+  font-size: $font-size-18;
+  line-height: $s18;
 
   .data-table {
     font-size: inherit;
@@ -11,6 +11,15 @@
 
   .form-group {
     margin-bottom: $s35;
+    p {
+      margin-bottom: $s15;
+    }
+
+    .text--help {
+      font-size: $font-size-18;
+      margin-top: 0px;
+      margin-bottom: $s15;
+    }
   }
 
   .form-question {
@@ -18,7 +27,7 @@
   }
 
   .button {
-    line-height: 2rem;
+    line-height: $s18;
     padding: $s10;
     margin-top: 0;
     margin-left: $s10;
@@ -26,35 +35,97 @@
     margin-bottom: 2rem;
     font-weight: normal;
     border-width: 1px;
-    box-shadow: 0 1px 0px rgba(#000, .5);
-    border-radius: $border-radius;
-    font-size: $font-size-25-small;
+    box-shadow: none;
+    border-radius: .4rem;
+    font-size: $font-size-18;
     [class^="icon-"], [class*=" icon-"] {
       vertical-align: 0;
     }
+    &:focus {
+      box-shadow: 0 0 0 5px $color-yellow, inset 0px 2px 0px rgba(#000, .15);
+    }
+    &:first-of-type {
+      margin-left: 0;
+    }
   }
 
+  .button--small {
+    font-size: $font-size-18;
+    border-radius: .4rem;
+    line-height: 1.5rem;
+    padding: .4rem $s10;
+  }
+
+  .button--big {
+    font-size: 1.8rem;
+    border-radius: .4rem;
+    line-height: $s25;
+    padding: .9rem $s15;
+  }
 
   .text-input {
     padding: 0 $s15;
-    height: 4.5rem;
+    height: 4rem;
     border-width: 1px;
-    font-size: $font-size-25-small;
+    font-size: $font-size-18;
     font-weight: normal;
     margin-bottom: 2rem;
   }
 
   .select {
-    line-height: 4.6rem;
-    height: 4.6rem;
+    line-height: 4rem;
+    border-width: 1px;
+    font-size: $font-size-18;
+    height: 4rem;
     &:after {
-      width: 4.2rem;
+      width: 4rem;
     }
   }
   .select__element {
-    font-size: $font-size-25-small;
+    font-size: $font-size-18;
     font-weight: normal;
     border: 1px solid $color-grey-darkest;
-    padding: 0 4.2rem 0 $s15;
+    height: 4rem;
+    padding: 0 4.0rem 0 $s15;
+  }
+
+  h1 {
+    font-size: 2.0rem;
+    line-height: 2.4rem;
+    margin-top: 4.0rem;
+    margin-bottom: 2.5rem;
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  h2 {
+    font-size: 1.8rem;
+    line-height: 2.2rem;
+    margin-top: 4.0rem;
+    margin-bottom: 2.5rem;
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  h3 {
+    font-size: 1.5rem;
+    line-height: 1.8rem;
+    margin-top: 4.0rem;
+    margin-bottom: 2.5rem;
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  .text--error {
+    @extend .text--red;
+    font-weight: $font-weight-bold;
+  }
+
+  .form-question {
+    font-size: $font-size-18;
+    line-height: $s18;
   }
 }

--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -6,6 +6,10 @@
     font-size: inherit;
     th, td {
       padding: $s15;
+      a {
+        color: $color-teal;
+        text-decoration: underline;
+      }
     }
   }
 

--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -11,6 +11,12 @@
         text-decoration: underline;
       }
     }
+
+    .row--error, .row--warning {
+      a {
+        color: $color-teal-dark;
+      }
+    }
   }
 
   .form-group {
@@ -46,7 +52,7 @@
       vertical-align: 0;
     }
     &:focus {
-      box-shadow: 0 0 0 5px $color-yellow, inset 0px 2px 0px rgba(#000, .15);
+      @include outline;
     }
     &:first-of-type {
       margin-left: 0;

--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -2,7 +2,7 @@
 $s5: 					0.5rem !default;
 $s10: 					1.0rem !default;
 $s15: 					1.5rem !default;
-$s19: 					1.9rem !default; // Default line height spacing for Honeycrisp Compact
+$s18: 					1.8rem !default; // Default line height spacing for Honeycrisp Compact
 $s25: 					2.5rem !default;
 $s35:					3.5rem !default;
 $s60:					6.0rem !default;
@@ -27,7 +27,7 @@ $font-size-60:			5rem !default;
 $font-size-35:			2.7rem !default;
 $font-size-25:			1.9rem !default;
 $font-size-25-small:	1.6rem !default;
-$font-size-19:          1.5rem !default; // Default font size for Honeycrisp Compact
+$font-size-18:          1.5rem !default; // Default font size for Honeycrisp Compact
 $font-size-15:			1.2rem !default;
 
 $font-weight-normal:	400 !default;

--- a/app/views/cfa/styleguide/pages/honeycrisp_compact.html.erb
+++ b/app/views/cfa/styleguide/pages/honeycrisp_compact.html.erb
@@ -32,6 +32,7 @@
   </div>
 </section>
 
+<%= render 'section', title: 'Typography', example: 'honeycrisp_compact/typography' %>
 <%= render 'section', title: 'Buttons', example: 'honeycrisp_compact/buttons' %>
 <%= render 'section', title: 'Form Elements', example: 'honeycrisp_compact/form_elements' %>
 <%= render 'section', title: 'Data Table', example: 'honeycrisp_compact/data_table' %>

--- a/app/views/examples/honeycrisp_compact/_buttons.html.erb
+++ b/app/views/examples/honeycrisp_compact/_buttons.html.erb
@@ -5,6 +5,16 @@
     <button class="button button--primary button--disabled" disabled>Disabled Primary Button</button>
   </div>
   <div>
+    <button class="button button--small button--primary">Button Small Primary</button>
+    <button class="button button--small">Button Small Secondary</button>
+    <button class="button button--small button--disabled" disabled>Disabled Primary Button Small</button>
+  </div>
+  <div>
+    <button class="button button--big button--primary">Button Big Primary</button>
+    <button class="button button--big">Button Big Secondary</button>
+    <button class="button button--big button--disabled" disabled>Disabled Button Big</button>
+  </div>
+  <div>
     <button class="button">Button</button>
     <button class="button button--disabled" disabled>Disabled Button</button>
   </div>

--- a/app/views/examples/honeycrisp_compact/_data_table.html.erb
+++ b/app/views/examples/honeycrisp_compact/_data_table.html.erb
@@ -5,6 +5,7 @@
       <th>Applicant</th>
       <th>Birth date</th>
       <th>Confirmation #</th>
+      <th>Notes</th>
     </tr>
     </thead>
     <tbody>
@@ -12,31 +13,37 @@
       <td>Applicant 1</td>
       <td>04/02/1988</td>
       <td>AKJHSD83K</td>
+      <td><a href="#">Link</a></td>
     </tr>
     <tr class="row--warning">
       <td>Applicant 2</td>
       <td>04/02/1988</td>
       <td>AKJHSD83K</td>
+      <td><a href="#">Link</a></td>
     </tr>
     <tr>
       <td>Applicant 3</td>
       <td>04/02/1988</td>
       <td>AKJHSD83K</td>
+      <td><a href="#">Link</a></td>
     </tr>
     <tr>
       <td>Applicant 4</td>
       <td>04/02/1988</td>
       <td>AKJHSD83K</td>
+      <td><a href="#">Link</a></td>
     </tr>
     <tr class="row--error">
       <td>Applicant 5</td>
       <td>04/02/1988</td>
       <td>AKJHSD83K</td>
+      <td><a href="#">Link</a></td>
     </tr>
     <tr>
       <td>Applicant 6</td>
       <td>04/02/1988</td>
       <td>AKJHSD83K</td>
+      <td><a href="#">Link</a></td>
     </tr>
     </tbody>
   </table>

--- a/app/views/examples/honeycrisp_compact/_form_elements.html.erb
+++ b/app/views/examples/honeycrisp_compact/_form_elements.html.erb
@@ -22,6 +22,7 @@
 
   <div class="form-group">
     <label for="apple_quality" class="form-question">What's your favorite apple quality?</label>
+    <p class="text--help">This is what help text in a form group looks like.</p>
     <div class="select">
       <select class="select__element" name="apple_quality" id="apple_quality">
         <option selected disabled>Choose a selection</option>

--- a/app/views/examples/honeycrisp_compact/_typography.erb
+++ b/app/views/examples/honeycrisp_compact/_typography.erb
@@ -1,0 +1,20 @@
+<div class="honeycrisp-compact">
+  <h1>Heading Level 1</h1>
+  <p>The apple wasn't bred to grow, store or ship well. It was bred for taste: crisp, with balanced sweetness and acidity.</p>
+
+  <h2>Heading Level 2</h2>
+  <p>The apple wasn't bred to grow, store or ship well. It was bred for taste: crisp, with balanced sweetness and acidity.</p>
+
+  <h3>Heading Level 3</h3>
+  <p>The apple wasn't bred to grow, store or ship well. It was bred for taste: crisp, with balanced sweetness and acidity.</p>
+
+  <body><p>This is what body text looks like.</p></body>
+
+  <p class="text--error">This is what error text looks like.</p>
+
+  <p class="text--help">This is what help text looks like.</p>
+
+  <p><a href="#">This is what link text looks like.</a></p>
+
+  <p><a href="#" class="link--subtle">This is what subtle link text looks like</a></p>
+</div>


### PR DESCRIPTION
Updates Honeycrisp Compact for recent style changes, represented here: https://www.figma.com/file/cW21hUVdIn5IcnxpjF5Cq1/Honeycrisp-working-file?node-id=295%3A195

Notable updates: 
- Adds some new button types (small and large)
- Makes spacing smaller
- Adds typography elements, h1, h2, h3 
- Fixes lost focus outline https://github.com/codeforamerica/honeycrisp-gem/issues/230
- Changes link colors for error or warning text in table 

Design consideration: 
The majority of the spacing and size variables are hard-coded here for font and line spacing. This is because Honeycrisp itself is very opinionated about how much line spacing goes with font size. Adding variables for Honeycrisp Compact to the variables file seemed like overkill since the sizes are not shared. 

<img width="1146" alt="Screen Shot 2021-02-11 at 1 46 51 PM" src="https://user-images.githubusercontent.com/5702758/107702908-c8be0c80-6c6f-11eb-9d4d-6188b44a059e.png">
<img width="1147" alt="Screen Shot 2021-02-11 at 1 47 00 PM" src="https://user-images.githubusercontent.com/5702758/107702911-c956a300-6c6f-11eb-85bf-2e5a44e5e0e2.png">
<img width="1140" alt="Screen Shot 2021-02-11 at 1 47 10 PM" src="https://user-images.githubusercontent.com/5702758/107702913-c9ef3980-6c6f-11eb-937c-32d7ac62d429.png">




<img width="1117" alt="Screen Shot 2021-02-11 at 1 46 37 PM" src="https://user-images.githubusercontent.com/5702758/107702898-c6f44900-6c6f-11eb-8044-c7a962866f90.png">

Co-authored-by: Whitney Schaefer <wschaefer@codeforamerica.org>
Co-authored-by: Rachel Edelman <rachel@codeforamerica.org>