### PR TITLE
Removes "full-bleed" mixin from slabs and overrides that masked the issue.

### DIFF
--- a/app/assets/stylesheets/atoms/_base.scss
+++ b/app/assets/stylesheets/atoms/_base.scss
@@ -18,11 +18,7 @@ body {
 }
 
 .page-wrapper {
-  overflow: hidden;
-  padding-left: $s15;
-  padding-right: $s15;
-  @include media($tablet-up) {
-    padding-left: $s35;
-    padding-right: $s35;
-  }
+  // usually page wrapper is wrapping everything in the page
+  // higher level wrapping classes like template-dashboard may
+  // override it with specific styles, but here it should not do anything.
 }

--- a/app/assets/stylesheets/atoms/_base.scss
+++ b/app/assets/stylesheets/atoms/_base.scss
@@ -19,6 +19,8 @@ body {
 
 .page-wrapper {
   // usually page wrapper is wrapping everything in the page
-  // higher level wrapping classes like template-dashboard may
-  // override it with specific styles, but here it should not do anything.
+  // higher level wrapping classes like template--dashboard. 
+  // While we no longer need this to apply values in Honeycrisp,
+  // leaving it here because I'd like there to be an indicator to
+  // future developers that page-wrapper is a "honeycrisp thing".
 }

--- a/app/assets/stylesheets/atoms/_slabs.scss
+++ b/app/assets/stylesheets/atoms/_slabs.scss
@@ -1,6 +1,5 @@
 .slab {
-  margin-left: 0;
-  margin-right: 0;
+  margin: inherit 0;
   position: relative;
   padding: $s60 0;
 

--- a/app/assets/stylesheets/atoms/_slabs.scss
+++ b/app/assets/stylesheets/atoms/_slabs.scss
@@ -1,5 +1,5 @@
 .slab {
-  margin: inherit 0;
+  margin: 0;
   position: relative;
   padding: $s60 0;
 

--- a/app/assets/stylesheets/atoms/_slabs.scss
+++ b/app/assets/stylesheets/atoms/_slabs.scss
@@ -1,10 +1,8 @@
 .slab {
-  @include full-bleed();
+  margin-left: 0;
+  margin-right: 0;
   position: relative;
-  padding: {
-    top: $s60;
-    bottom: $s60;
-  }
+  padding: $s60 0;
 
   &:last-child {
     border-bottom: 0;

--- a/app/assets/stylesheets/atoms/_utilities.scss
+++ b/app/assets/stylesheets/atoms/_utilities.scss
@@ -7,26 +7,20 @@
   }
 }
 
-// Use this if an element should take up the full width of the screen.
+// If a page/section has a wrapping component that adds default margin/padding (like page-wrapper on template--dashboard)
+// use this mixin to force a full-width child.
 @mixin full-bleed() {
-  margin: {
-    left: -$s15;
-    right: -$s15;
-  }
-  padding: {
-    left: $s15;
-    right: $s15;
-  }
+  margin-left: -$s15;
+  margin-right: -$s15;
+  padding-left: $s15;
+  padding-right: $s15;
+
 
   @include media($tablet-up) {
-    margin: {
-      left: -$s35;
-      right: -$s35;
-    }
-    padding: {
-      left: $s35;
-      right: $s35;
-    }
+    margin-left: -$s35;
+    margin-right: -$s35;
+    padding-left: $s35;
+    padding-right: $s35;
   }
 }
 

--- a/app/assets/stylesheets/templates/_dashboard.scss
+++ b/app/assets/stylesheets/templates/_dashboard.scss
@@ -2,7 +2,12 @@
   font-size: $font-size-25-small;
 
   .page-wrapper, .main-footer {
-    overflow: auto;
+    padding-left: $s15;
+    padding-right: $s15;
+    @include media($tablet-up) {
+      padding-left: $s35;
+      padding-right: $s35;
+    }
     min-width: $site-max-width;
   }
 


### PR DESCRIPTION
While working on a feature in GYR, I (@bytheway875) was struggling with getting a header on a table to be sticky. After lots of research I found [this article](https://www.designcise.com/web/tutorial/how-to-fix-issues-with-css-position-sticky-not-working) and I realized that you cannot use `position:sticky` on a child of a parent that has an overflow value of anything other than `overflow:visible.` I thought "that can't be my problem because I don't have `overflow: auto` or `overflow:hidden` set on anything in the app to my knowledge. I ran the code snippet that the article provided: 

```
let parent = document.querySelector('.sticky').parentElement;

while (parent) {
    const hasOverflow = getComputedStyle(parent).overflow;
    if(hasOverflow !== 'visible') {
        console.log(hasOverflow, parent);
    }
    parent = parent.parentElement;
}
```

which led me to the culprit: page-wrapper. .page-wrapper applied an overflow: auto to unscoped page-wrappers, and overflow-hidden to page-wrappers nested inside of .template--dashboard. This was added, I believe, to fix some issues we were having because of the way we set full-width containers in the application. Instead of a full width container having 0 margin and 0 padding, the mixin full-bleed() sets positive padding equal to a negative margin. When you nest classes that employ "full-bleed" inside each other, the browser gets super confused about what the full width of the container is and it becomes almost guaranteed that one of your full-width components is going to end up taking up more than 100% width of the parent, causing a horizontal scroll bar that can then be hidden by adding any overflow value other than `visible` (thus the implementations of `overflow: hidden` and `overflow:auto`) on page wrapper.

Ash and I added some notes to make it more clear when to use full-bleed mixin (it has its uses, especially when you want a full width component inside of a component that adds margin to the page, which is what page-wrapper does on GCF's template dashboard.), and removed full-bleed from slab. We also flattened down some of the sass-specific attribute naming because I _think_ that I've been experiencing unexpected inheritance issues due to the way that sass "resolves" non-standard css functionality into real css. What I mean by that is, I'm not sure whether something like 
```
  margin { 
    top: 5px; 
    left: 10px;
  }
```

gets resolved to `margin: 5px 0 0 10px` or `margin-top: 5px; margin-left;`, and that can have some unexpected consequences or at least confusion in a design system in which people are wanting to override those values.



Co-authored-by: Shannon Byrne <sbyrne@codeforamerica.org>