### PR TITLE
Remove double init of honeycrisp javascript.

### DIFF
--- a/app/assets/javascripts/cfa_styleguide_main.js
+++ b/app/assets/javascripts/cfa_styleguide_main.js
@@ -14,5 +14,3 @@
 //= require jquery_ujs
 //= require sidebar
 //= require honeycrisp
-
-Honeycrisp.init();


### PR DESCRIPTION
Thanks for a great bug report @lkogler @wschaefer -- when you said incrementor was incrementing by two, it seemed likely we were calling Honeycrisp.init() 2x, which was adding double listeners! 

Honeycrisp.init() is also being called at the end of  honeycrisp.js itself, so we don't need the call to Honeycrisp.init() in the manifest.