### PR TITLE
Darkens unselected tabs by 5% in tab bar

### DIFF
--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -1,115 +1,118 @@
 // Spacing Units
-$s5: 					0.5rem !default;
-$s10: 					1.0rem !default;
-$s15: 					1.5rem !default;
-$s18: 					1.8rem !default; // Default line height spacing for Honeycrisp Compact
-$s25: 					2.5rem !default;
-$s35:					3.5rem !default;
-$s60:					6.0rem !default;
-$s95:					9.5rem !default;
-$s155:					15.5rem !default;
-$s250:					25.0rem !default;
+$s5:                        0.5rem !default;
+$s10:                       1.0rem !default;
+$s15:                       1.5rem !default;
+$s18:                       1.8rem !default; // Default line height spacing for Honeycrisp Compact
+$s25:                       2.5rem !default;
+$s35:                       3.5rem !default;
+$s60:                       6.0rem !default;
+$s95:                       9.5rem !default;
+$s155:                      15.5rem !default;
+$s250:                      25.0rem !default;
 
 
 // Fonts
-$font-system:         	-apple-system, BlinkMacSystemFont,
-                        "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
-                        "Fira Sans", "Droid Sans", "Helvetica Neue",
-                        sans-serif;
+$font-system:               -apple-system, BlinkMacSystemFont,
+                            "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+                            "Fira Sans", "Droid Sans", "Helvetica Neue",
+                            sans-serif;
 
 /* use !important to prevent issues with browser extensions that change fonts */
-$font-icon:           	'Material Icons' !important;;
+$font-icon:                 'Material Icons' !important;;
 
 
 // Typopgraphy
-$em-base:             	62.5% !default;	// Changes root font size to 10px for easier rem calculations
-$font-size-60:			5rem !default;
-$font-size-35:			2.7rem !default;
-$font-size-25:			1.9rem !default;
-$font-size-25-small:	1.6rem !default;
-$font-size-18:          1.5rem !default; // Default font size for Honeycrisp Compact
-$font-size-15:			1.2rem !default;
+$em-base:                   62.5% !default;	// Changes root font size to 10px for easier rem calculations
+$font-size-60:              5rem !default;
+$font-size-35:              2.7rem !default;
+$font-size-25:              1.9rem !default;
+$font-size-25-small:        1.6rem !default;
+$font-size-18:              1.5rem !default; // Default font size for Honeycrisp Compact
+$font-size-15:              1.2rem !default;
 
-$font-weight-normal:	400 !default;
-$font-weight-bold:		700 !default;
-$font-weight-light:		300 !default;
+$font-weight-normal:	    400 !default;
+$font-weight-bold:		    700 !default;
+$font-weight-light:         300 !default;
 
 
 // Colors
-$color-green: 			#00891B !default;
-$color-green-light: 	#EBFFEF !default;
+$color-green: 			    #00891B !default;
+$color-green-light: 	    #EBFFEF !default;
 
-$color-grey: 			#CFC5BF !default;
-$color-grey-light: 		#F7F5F4 !default;
-$color-grey-dark: 		#5F5854 !default;
-$color-grey-darkest: 	#121111 !default;
+$color-grey: 			    #CFC5BF !default;
+$color-grey-light: 		    #F7F5F4 !default;
+$color-grey-dark: 		    #5F5854 !default;
+$color-grey-darkest: 	    #121111 !default;
 
-$color-magenta: 		#A6005E !default;
-$color-magenta-light: 	#FFEAF6 !default;
-$color-magenta-dark:  	#66013A !default;
+$color-magenta: 		    #A6005E !default;
+$color-magenta-light: 	    #FFEAF6 !default;
+$color-magenta-dark:  	    #66013A !default;
 
-$color-red: 			#D13F00 !default;
-$color-red-light: 		#FCE3D9 !default;
+$color-red: 			    #D13F00 !default;
+$color-red-light: 		    #FCE3D9 !default;
 
-$color-orange:        	#D48C00 !default;
+$color-orange:        	    #D48C00 !default;
 
-$color-teal: 			#008060 !default;
-$color-teal-light: 		#EBFFFA !default;
-$color-teal-dark: 		#034E46 !default;
+$color-teal: 			    #008060 !default;
+$color-teal-light: 		    #EBFFFA !default;
+$color-teal-dark: 		    #034E46 !default;
 
-$color-yellow: 			#FFAE00 !default;
-$color-yellow-light: 	#FFF2D1 !default;
+$color-yellow: 			    #FFAE00 !default;
+$color-yellow-light: 	    #FFF2D1 !default;
 
-$color-background:    	$color-grey-light !default;
+$color-background:    	    $color-grey-light !default;
 
-$color-link-default:    $color-teal !default;
-$color-link-hover:      $color-teal-dark !default;
-$color-link-visited:    $color-teal !default;
-$color-link-active:     $color-teal !default;
+$unselected-tab-background: darken($color-background, 5%);
+$selected-tab-background:   $color-background;
+
+$color-link-default:        $color-teal !default;
+$color-link-hover:          $color-teal-dark !default;
+$color-link-visited:        $color-teal !default;
+$color-link-active:         $color-teal !default;
 
 // Breakpoints
-$small-mobile-up:     	320px !default;
-$mobile-up:           	481px !default;
-$tablet-up:           	601px !default;
-$site-max-up:         	961px !default;
+$small-mobile-up:           320px !default;
+$mobile-up:                 481px !default;
+$tablet-up:           	    601px !default;
+$site-max-up:         	    961px !default;
 
 
 // Magic Numbers
-$site-max-width:      	960px !default;
-$footer-height-home:  	340px !default;
-$footer-height:       	100px !default;
-$sidebar-width:         250px !default;
-$site-margins:			$s35 !default;
-$border-radius:       	$s5 !default;
-$border-radius-large: 	$s10 !default;
-$tooltip-width:       	$s250 !default;
+$site-max-width:            960px !default;
+$footer-height-home:  	    340px !default;
+$footer-height:       	    100px !default;
+$sidebar-width:             250px !default;
+$site-margins:              $s35 !default;
+$border-radius:             $s5 !default;
+$border-radius-large:       $s10 !default;
+$tooltip-width:             $s250 !default;
 
 
 // Image Sizes
-$width-image-icon:   	$s15 !default;
-$width-image-small:   	$s60 !default;
-$width-image-med:     	$s95 !default;
-$width-image-large:   	$s155 !default;
+$width-image-icon:          $s15 !default;
+$width-image-small:         $s60 !default;
+$width-image-med:           $s95 !default;
+$width-image-large:         $s155 !default;
 
 
 // Form Widths
-$width-form-med:	    13em !default;
-$width-form-long:	    25em !default;
-$width-form-short:     	8em !default;
+$width-form-med:            13em !default;
+$width-form-long:           25em !default;
+$width-form-short:          8em !default;
 
-$width-form-casenumber: 8em !default;
-$width-form-phone:      11em !default;
-$width-form-name:       12em !default;
-$width-form-zip:        6.5em !default;
-$width-form-ssn:        10em !default;
-$width-form-searchbar:  30em !default;
+$width-form-casenumber:     8em !default;
+$width-form-phone:          11em !default;
+$width-form-name:           12em !default;
+$width-form-zip:            6.5em !default;
+$width-form-ssn:            10em !default;
+$width-form-searchbar:      30em !default;
 
 // Shadows
-$box-shadow: 			0px 3px 5px rgba(0,0,0,.15) !default;
+$box-shadow:                0px 3px 5px rgba(0,0,0,.15) !default;
 
 // Animations
-$animation-fast:      	.1s ease-out !default;
-$animation-med:      	.2s ease-out !default;
+$animation-fast:            .1s ease-out !default;
+$animation-med:             .2s ease-out !default;
 
 // Icons
 $icons: (

--- a/app/assets/stylesheets/molecules/_tabs.scss
+++ b/app/assets/stylesheets/molecules/_tabs.scss
@@ -8,7 +8,7 @@
 }
 
 .tab-bar__tab {
-  background-color: darken($color-background, 5%);
+  background-color: $unselected-tab-background;
   border: 2px solid $color-grey-darkest;
   color: $color-grey-darkest;
   display: block;
@@ -26,13 +26,13 @@
   }
 
   &.is-selected {
-    background-color: $color-background;
+    background-color: $selected-tab-background;
     color: $color-grey-darkest;
     font-weight: 600;
     z-index: 2;
 
     &:before {
-      background-color: $color-background;
+      background-color: $selected-tab-background;
       content: '';
       position: absolute;
       display: block;

--- a/app/assets/stylesheets/molecules/_tabs.scss
+++ b/app/assets/stylesheets/molecules/_tabs.scss
@@ -8,7 +8,7 @@
 }
 
 .tab-bar__tab {
-  background-color: $color-grey-light;
+  background-color: darken($color-background, 5%);
   border: 2px solid $color-grey-darkest;
   color: $color-grey-darkest;
   display: block;


### PR DESCRIPTION
closes #152 

It was originally proposed to set the background color of selected tabs to white in order to differentiate the selected tab from the unselected tabs in a tab bar. 

After some discussion between @bengolder and @racheledelman , it was noted that the tab bar looks different in the styleguide than it does on most projects. The selected tab used `$background-color`, which was white for the styleguide, while the tab bar itself was set to `$color-grey-light`, so the selected tab stood out by accident in the styleguide and blended in in other places like GCF. 

This PR sets the tab bar to use the background color darkened by 5%. A selected tab will show the normal background color. Below you can see the difference more clearly: 

Before on GCF 

<img width="1440" alt="Screen Shot 2021-02-26 at 11 25 14 AM" src="https://user-images.githubusercontent.com/5702758/109345664-57f92180-7825-11eb-9975-f337b28eb0b1.png">
<img width="1440" alt="Screen Shot 2021-02-26 at 11 25 04 AM" src="https://user-images.githubusercontent.com/5702758/109345670-5891b800-7825-11eb-8384-f1418bdc8fd3.png">


After on GCF 

<img width="1439" alt="Screen Shot 2021-02-26 at 11 17 07 AM" src="https://user-images.githubusercontent.com/5702758/109345577-3a2bbc80-7825-11eb-8888-fb1ea599a752.png">

<img width="1440" alt="Screen Shot 2021-02-26 at 11 16 58 AM" src="https://user-images.githubusercontent.com/5702758/109345581-3b5ce980-7825-11eb-9a48-e0b5997f5109.png">
