### PR TITLE
Consolidate max width logic

### DIFF
--- a/app/assets/stylesheets/atoms/_grid.scss
+++ b/app/assets/stylesheets/atoms/_grid.scss
@@ -1,6 +1,5 @@
 .grid {
-	@include outer-container();
-	max-width: $site-max-width;
+	@include outer-container($site-max-width);
 
 	@include media($tablet-up) {
 		// Defines width of element


### PR DESCRIPTION
Fixes #235. 

We were setting a value for max-width twice on .grid. Since the outer container mixin already supports passing in a custom max width, we can pass in the value we want instead of overriding it.

<img width="563" alt="Screen Shot 2021-02-26 at 3 24 55 PM" src="https://user-images.githubusercontent.com/4494389/109365901-019cda80-7847-11eb-8b96-965428d0414c.png">
