### PR TITLE
Add .header--sortable to honeycrisp_compact data-table

### DIFF
--- a/app/assets/stylesheets/_honeycrisp-compact.scss
+++ b/app/assets/stylesheets/_honeycrisp-compact.scss
@@ -4,8 +4,12 @@
 
   .data-table {
     font-size: inherit;
+
     th, td {
       padding: $s15;
+    }
+
+    td {
       a {
         color: $color-teal;
         text-decoration: underline;
@@ -15,6 +19,23 @@
     .row--error, .row--warning {
       a {
         color: $color-teal-dark;
+      }
+    }
+
+    .header--sortable {
+      white-space: nowrap;
+
+      .sort-icon::after {
+        display: inline-block;
+        margin-left: $s15;
+      }
+
+      .sort-icon--ascending::after {
+        content: '▲';
+      }
+
+      .sort-icon--descending::after {
+        content: '▼';
       }
     }
   }

--- a/app/views/examples/honeycrisp_compact/_data_table.html.erb
+++ b/app/views/examples/honeycrisp_compact/_data_table.html.erb
@@ -2,7 +2,11 @@
   <table class="data-table">
     <thead>
     <tr>
-      <th>Applicant</th>
+      <th class="header--sortable">
+        <a href="#" class="sort-icon sort-icon--ascending">
+          Applicant
+        </a>
+      </th>
       <th>Birth date</th>
       <th>Confirmation #</th>
       <th>Notes</th>


### PR DESCRIPTION
We need this for the GCF CBO dashboard.

This also updates <th> link styles so that only the links in <td>'s are
colored green.

Co-authored-by: Travis Grathwell <tgrathwell@codeforamerica.org>