### PR TITLE
Add calfresh_logo.png to precompiled assets

### DIFF
--- a/lib/cfa/styleguide/engine.rb
+++ b/lib/cfa/styleguide/engine.rb
@@ -9,6 +9,7 @@ module Cfa
           cfa_styleguide_main.js
           prism.css
           prism.js
+          calfresh_logo.png
         )
       end
 


### PR DESCRIPTION
It's needed for host applications if they mount /cfa/styleguide, since it's used in the styleguide documentation page. This should prevent host applications from getting a 500 error for missing precompiled assets, which is currently happening on GYR and CGLA.

There are likely more robust solutions, but this is the one I have.

Closes #250 