### PR TITLE
Set default attributes on relevant inputs

### DIFF
--- a/app/helpers/cfa/styleguide/cfa_v2_form_builder.rb
+++ b/app/helpers/cfa/styleguide/cfa_v2_form_builder.rb
@@ -14,6 +14,8 @@ module Cfa
                          wrapper_options: {},
                          label_options: {},
                          **input_options)
+        input_options = standard_options.merge(input_options)
+
         if help_text.present?
           help_text_id = help_text_id(method)
           help_text_html = help_text_html(help_text, help_text_id)
@@ -49,6 +51,8 @@ module Cfa
           **select_html_options,
           &block
         )
+        select_html_options = standard_options.merge(select_html_options)
+
         if object.errors[method].any?
           error_id = error_id(method)
           error_html = errors_for(object, method, error_id)
@@ -225,6 +229,15 @@ module Cfa
         name = object_name.to_s.gsub(/([\[\(])|(\]\[)/, "_").gsub(/[\]\)]/, "")
 
         position ? "#{name}_#{method}_#{position}" : "#{name}_#{method}"
+      end
+
+      def standard_options
+        {
+          autocomplete: "off",
+          autocorrect: "off",
+          autocapitalize: "off",
+          spellcheck: "false",
+        }
       end
     end
   end

--- a/spec/helpers/cfa_v2_form_builder_spec.rb
+++ b/spec/helpers/cfa_v2_form_builder_spec.rb
@@ -83,18 +83,28 @@ describe Cfa::Styleguide::CfaV2FormBuilder, type: :view do
       expect(label.text).to include("(Optional)")
     end
 
+    it "sets default options on the input" do
+      input_html = Nokogiri::HTML.fragment(output).at_css("input")
+      expect(input_html.get_attribute("autocomplete")).to eq("off")
+      expect(input_html.get_attribute("autocorrect")).to eq("off")
+      expect(input_html.get_attribute("autocapitalize")).to eq("off")
+      expect(input_html.get_attribute("spellcheck")).to eq("false")
+    end
+
     context "when options provided" do
       let(:output) do
         form_builder.cfa_text_field(:example_method_with_validation,
                                     "Example method with validation",
                                     class: "foo",
                                     placeholder: "my text",
-                                    disabled: true)
+                                    disabled: true,
+                                    autocomplete: true)
       end
 
       it "passes options to the input" do
         input_html = Nokogiri::HTML.fragment(output).at_css("input")
         expect(input_html.get_attribute("disabled")).to be_truthy
+        expect(input_html.get_attribute("autocomplete")).to be_truthy
         expect(input_html.get_attribute("placeholder")).to eq("my text")
       end
 
@@ -242,6 +252,11 @@ describe Cfa::Styleguide::CfaV2FormBuilder, type: :view do
       select_html = Nokogiri::HTML.fragment(output).at_css("select")
       expect(select_html.classes).to include("select__element")
       expect(select_html.parent.classes).to include("select")
+    end
+
+    it "sets default options on the input" do
+      select_html = Nokogiri::HTML.fragment(output).at_css("select")
+      expect(select_html.get_attribute("autocomplete")).to eq("off")
     end
 
     context "when select_options provided" do


### PR DESCRIPTION
Prevent autocompletion by browser, autocorrect, autocapitalization, and
spellcheck. Belief is that they are not desirable for our main use cases
(eg shared computers or data entry for multiple people, phones &
names & addresses).

Can be overriden by passing HTML options to form field.

This matches behavior for our previous form builder.

MDN docs:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-autocorrect (non-standard)

And:
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

Closes #263 