### PR TITLE
update readme to specify 'main' as the branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you have any thoughts or questions about the project, get in touch at <a href
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem'
+gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem', branch: :main
 ```
 
 And then execute:


### PR DESCRIPTION
When trying to use the honeycrisp gem, we ran `bundle install` and received the error: 
```
fatal: Needed a single revision
Revision master does not exist in the repository https://github.com/codeforamerica/honeycrisp-gem. Maybe you misspelled it?
```
In order to get `bundle install` to work, we needed to specify `main` as the branch name in Gemfile. See: https://github.com/rubygems/rubygems/issues/4009