### PR TITLE
Allow feedback survey radio to accept focus

### DIFF
--- a/app/assets/stylesheets/honeycrisp/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/honeycrisp/molecules/_form-molecules.scss
@@ -302,7 +302,7 @@
   }
 
   .radio-button input {
-    display: none;
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
# What

Fix #300 by using `opacity` instead of `display: none` to hide custom inputs.