### PR TITLE
Adding role for aria-labeled progressbar

### DIFF
--- a/app/views/components/molecules/_progress_step_bar.html.erb
+++ b/app/views/components/molecules/_progress_step_bar.html.erb
@@ -3,7 +3,7 @@
 <% label_id = "progress-step-bar--#{current_step}-#{step_count}-label".downcase %>
 
 <div class="progress-step-bar">
-  <div class="progress-step-bar__bar" aria-labelledby="<%= label_id %>">
+  <div class="progress-step-bar__bar" role="progressbar" aria-labelledby="<%= label_id %>">
     <% (1..step_count).each do |step_number| %>
       <% if step_number < current_step %>
         <div class="progress-step-bar__step progress-step-bar__step--completed"></div>


### PR DESCRIPTION
related to Rule ID: aria-allowed-attr.

See:
https://dequeuniversity.com/rules/axe/4.6/aria-allowed-attr?application=axeAPI
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role