### PR TITLE
Fix syntax error on Ruby 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -659,7 +659,7 @@ Lint/UselessRuby2Keywords: # new in 1.23
 Metrics/CollectionLiteralLength: # new in 1.47
   Enabled: true
 Naming/BlockForwarding: # new in 1.24
-  Enabled: true
+  Enabled: false
 Security/CompoundHash: # new in 1.28
   Enabled: true
 Security/IoMethods: # new in 1.22

--- a/app/helpers/cfa/styleguide/cfa_form_builder.rb
+++ b/app/helpers/cfa/styleguide/cfa_form_builder.rb
@@ -341,7 +341,7 @@ module Cfa
         label_text,
         collection,
         options = {},
-        &
+        &block
       )
 
         html_options = {
@@ -363,7 +363,7 @@ module Cfa
           <div class="form-group#{error_state(object, method)}">
             #{formatted_label}
             <div class="select">
-              #{select(method, collection, options, html_options_with_errors, &)}
+              #{select(method, collection, options, html_options_with_errors, &block)}
             </div>
             #{errors_for(object, method)}
           </div>

--- a/app/models/cfa/styleguide/form_example.rb
+++ b/app/models/cfa/styleguide/form_example.rb
@@ -21,7 +21,7 @@ module Cfa
 
       validates_presence_of :example_method_with_validation # For tests
 
-      def method_missing(method_name, *args, **kwargs, &)
+      def method_missing(method_name, *args, **kwargs, &block)
         if method_name.to_s.starts_with?("example_method_with_validation") && errors[method_name].empty?
           errors.add(method_name, "This is an example error message.")
         end


### PR DESCRIPTION
We jumped the gun on removing unused `&block` variable names -- that syntax isn't supported until Ruby 3.1.

Until then, let's keep these anonymous block arguments.