### PR TITLE
Make reveal more accessible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     - run:
         name: "Update Node.js and npm"
         command: |
-          curl -sSL "https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v14.15.0-linux-x64/bin/node
+          curl -sSL "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v20.11.1-linux-x64/bin/node
           curl https://www.npmjs.com/install.sh | sudo bash
     - run:
         name: "Configure Bundler"
@@ -69,7 +69,7 @@ jobs:
     - run:
         name: "Update Node.js and npm"
         command: |
-          curl -sSL "https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v14.15.0-linux-x64/bin/node
+          curl -sSL "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v20.11.1-linux-x64/bin/node
           curl https://www.npmjs.com/install.sh | sudo bash
     - run:
         name: "Configure Bundler"

--- a/app/assets/javascripts/honeycrisp.js
+++ b/app/assets/javascripts/honeycrisp.js
@@ -142,10 +142,10 @@ var revealer = (function() {
                 var self = revealer;
                 $(self).addClass('is-hiding-content');
                 var revealLink = $(self).find('.reveal__link')
-                $(self).find('.reveal__link').each(function(i, link) {
-                   link.setAttribute('aria-expanded', 'false')
+                revealLink.each(function(i, link) {
+                   link.setAttribute('aria-expanded', false)
                 })
-                $(self).find('.reveal__link').click(function(e) {
+                revealLink.click(function(e) {
                     e.preventDefault();
                     $(self).toggleClass('is-hiding-content');
 

--- a/app/assets/javascripts/honeycrisp.js
+++ b/app/assets/javascripts/honeycrisp.js
@@ -141,9 +141,19 @@ var revealer = (function() {
             $('.reveal').each(function(index, revealer) {
                 var self = revealer;
                 $(self).addClass('is-hiding-content');
+                var revealLink = $(self).find('.reveal__link')
+                $(self).find('.reveal__link').each(function(i, link) {
+                   link.setAttribute('aria-expanded', 'false')
+                })
                 $(self).find('.reveal__link').click(function(e) {
                     e.preventDefault();
                     $(self).toggleClass('is-hiding-content');
+
+                    if (this.getAttribute('aria-expanded') === 'false') {
+                        this.setAttribute('aria-expanded', 'true');
+                    } else {
+                        this.setAttribute('aria-expanded', 'false')
+                    }
                 });
             });
         }

--- a/app/assets/javascripts/honeycrisp.js
+++ b/app/assets/javascripts/honeycrisp.js
@@ -141,11 +141,11 @@ var revealer = (function() {
             $('.reveal').each(function(index, revealer) {
                 var self = revealer;
                 $(self).addClass('is-hiding-content');
-                var revealLink = $(self).find('.reveal__link')
-                revealLink.each(function(i, link) {
+                var revealButton = $(self).find('.reveal__button')
+                revealButton.each(function(i, link) {
                    link.setAttribute('aria-expanded', false)
                 })
-                revealLink.click(function(e) {
+                revealButton.click(function(e) {
                     e.preventDefault();
                     $(self).toggleClass('is-hiding-content');
 

--- a/app/assets/stylesheets/honeycrisp/molecules/_reveal.scss
+++ b/app/assets/stylesheets/honeycrisp/molecules/_reveal.scss
@@ -1,4 +1,4 @@
-.reveal__link {
+.reveal__button {
   @include outline;
   cursor: pointer;
   display: inline-block;
@@ -34,7 +34,7 @@
 .reveal {
   margin-bottom: 1em;
   &.is-hiding-content {
-    .reveal__link {
+    .reveal__button {
       &:after {
         content: '\a0'+map_get($icons, keyboard_arrow_right);
       }

--- a/app/assets/stylesheets/honeycrisp/molecules/_reveal.scss
+++ b/app/assets/stylesheets/honeycrisp/molecules/_reveal.scss
@@ -1,5 +1,6 @@
 .reveal__link {
   @include outline;
+  cursor: pointer;
   display: inline-block;
   text-decoration: none;
   color: $color-teal-dark;

--- a/app/views/components/molecules/_reveal.html.erb
+++ b/app/views/components/molecules/_reveal.html.erb
@@ -1,6 +1,6 @@
 <div class="reveal">
-  <button type="button" href="#" class="reveal__link" aria-controls="reveal__content_id"><%= title %></button>
-  <div class="reveal__content" id="reveal__content_id">
+  <button class="reveal__button" aria-expanded="true"><%= title %></button>
+  <div class="reveal__content">
     <%= yield %>
   </div>
 </div>

--- a/app/views/components/molecules/_reveal.html.erb
+++ b/app/views/components/molecules/_reveal.html.erb
@@ -1,4 +1,4 @@
-<div class="reveal">
+<div class="reveal" aria-live="polite">
   <p><button href="#" class="reveal__link" aria-controls="reveal__content_id"><%= title %></button></p>
   <div class="reveal__content" id="reveal__content_id">
     <%= yield %>

--- a/app/views/components/molecules/_reveal.html.erb
+++ b/app/views/components/molecules/_reveal.html.erb
@@ -1,6 +1,6 @@
 <div class="reveal">
-  <p><a href="#" class="reveal__link"><%= title %></a></p>
-  <div class="reveal__content">
+  <p><button href="#" class="reveal__link" aria-controls="reveal__content_id"><%= title %></button></p>
+  <div class="reveal__content" id="reveal__content_id">
     <%= yield %>
   </div>
 </div>

--- a/app/views/components/molecules/_reveal.html.erb
+++ b/app/views/components/molecules/_reveal.html.erb
@@ -1,5 +1,5 @@
-<div class="reveal" aria-live="polite">
-  <p><button href="#" class="reveal__link" aria-controls="reveal__content_id"><%= title %></button></p>
+<div class="reveal">
+  <button type="button" href="#" class="reveal__link" aria-controls="reveal__content_id"><%= title %></button>
   <div class="reveal__content" id="reveal__content_id">
     <%= yield %>
   </div>


### PR DESCRIPTION
Allows Safari screenreaders to announce expanded/collapsed state of the reveal when clicked/pressed on to open/close

https://www.pivotaltracker.com/story/show/186891325