### PR TITLE
Set text align start on reveal button

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,7 @@
 
 ## Migrating from <= 0.11.x to 0.12.0
 In `0.12.0` we improved the accessibility of the Reveal component. Now the link that opened the reveal is a button with `aria-expanded` attributes which enables VoiceOver to announce the collapsed/expanded state of the reveal when clicked/toggled via keyboard in Safari.
+Make sure to update any references to `.reveal__link` to `.reveal__button` in your repository if present.
 
 *Note*: this does not currently work in Chrome/Firefox.
 

--- a/app/assets/stylesheets/honeycrisp/molecules/_reveal.scss
+++ b/app/assets/stylesheets/honeycrisp/molecules/_reveal.scss
@@ -2,6 +2,7 @@
   @include outline;
   cursor: pointer;
   display: inline-block;
+  text-align: start;
   text-decoration: none;
   color: $color-teal-dark;
   border: 2px solid $color-teal-dark;


### PR DESCRIPTION
Merged recent updated version of honeycrisp (0.12.0) to GCF codebase and saw that percy diff showed change in alignment of the button text when viewed in a small screen. 

![Screenshot 2024-02-28 at 2 11 54 PM](https://github.com/codeforamerica/honeycrisp-gem/assets/18129274/aa09ea27-e131-4904-841a-d1208cd9a27a)
