### PR TITLE
Update rails in the format recommended

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ DEPENDENCIES
   percy-capybara (~> 5.0.0)
   pry-byebug
   rack (>= 2.0.8)
-  rails (= 7.0.8.1)
+  rails (~> 7.0.8.1)
   rake (>= 12.3.3)
   rspec
   rspec-rails


### PR DESCRIPTION
I ran the recommended command and it changed the gemlock file for me, so I created a PR to address it.

```
arin✨ honeycrisp-gem [main] bundle exec rake release\[0.13.1\]

== Bumping version number ==

Uncommitted changes found. Please commit or stash. Aborting.

== Command ["gem bump --no-commit --version 0.13.1"] failed ==
arin✨ honeycrisp-gem [main] git st
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   Gemfile.lock

no changes added to commit (use "git add" and/or "git commit -a")
arin✨ honeycrisp-gem [main] git add -p
diff --git a/Gemfile.lock b/Gemfile.lock
index 3d6e001..4586799 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ DEPENDENCIES
   percy-capybara (~> 5.0.0)
   pry-byebug
   rack (>= 2.0.8)
-  rails (= 7.0.8.1)
+  rails (~> 7.0.8.1)
   rake (>= 12.3.3)
   rspec
   rspec-rails
(1/1) Stage this hunk [y,n,q,a,d,e,?]? y
```