### PR TITLE
Revert "Fix - "None of the above" in checkbox set (Breaking)"

### DIFF
--- a/app/assets/javascripts/honeycrisp.js
+++ b/app/assets/javascripts/honeycrisp.js
@@ -212,27 +212,23 @@ var inputGroupSelector = (function() {
 var noneOfTheAbove = (function() {
     var noneOf = {
         init: function () {
-            var $noneCheckboxes = $('input[id^=none__checkbox]');
-            var $otherCheckboxes = $('input[type=checkbox]').not('[id^=none__checkbox]');
+            var $noneCheckbox = $('#none__checkbox');
+            var $otherCheckboxes = $('input[type=checkbox]').not('#none__checkbox');
 
             // Uncheck None if another checkbox is checked
-            $otherCheckboxes.click(function (e) {
-                var $name = this.name
-                var $noneCheckbox = $('#none__checkbox-' + $name.substring(0, $name.length - 2));
+            $otherCheckboxes.click(function(e) {
                 $noneCheckbox.prop('checked', false);
                 $noneCheckbox.parent().removeClass('is-selected');
             });
 
             // Uncheck all others if None is checked
-            $noneCheckboxes.click(function (e) {
-                var $id = $(this).attr('id')
-                var $noneSiblingCheckboxes = $('input[id^=' + $id.substring(15));
-                $noneSiblingCheckboxes.prop('checked', false);
-                $noneSiblingCheckboxes.parent().removeClass('is-selected');
+            $noneCheckbox.click(function(e) {
+                $otherCheckboxes.prop('checked', false);
+                $otherCheckboxes.parent().removeClass('is-selected');
 
                 // If we just unchecked an <input> with a follow-up, let's reset the follow-up questions
                 // so it hides properly.
-                var $enclosingFollowUp = $(this).closest('.question-with-follow-up');
+                var $enclosingFollowUp = $noneCheckbox.closest('.question-with-follow-up');
                 if ($enclosingFollowUp) {
                     followUpQuestion.update($enclosingFollowUp);
                 }


### PR DESCRIPTION
Reverts codeforamerica/honeycrisp-gem#320

-- 
This broke the functionality for Rails projects, which use formbuilder. We cannot easily manipulate the id of the html elements as in we can in our java projects. In order to unblock further development for Rails projects, we made a decision to revert this. We should figure out a way to fix this for java projects in the future.