### PR TITLE
Move the `uglifier` initialization out of the method to avoid re-initializing it every time the method is called.

### DIFF
--- a/lib/sprockets_extension/uglifier_source_maps_compressor.rb
+++ b/lib/sprockets_extension/uglifier_source_maps_compressor.rb
@@ -1,28 +1,46 @@
 require "sprockets/digest_utils"
 require "sprockets/uglifier_compressor"
+require "json"
+require "fileutils"
 
 class UglifierSourceMapsCompressor < Sprockets::UglifierCompressor
+  def initialize
+    super
+    @uglifier = Sprockets::Autoload::Uglifier.new
+  end
+
   def call(input)
     data = input.fetch(:data)
     name = input.fetch(:name)
 
-    uglifier ||= Sprockets::Autoload::Uglifier.new
-    compressed_data, sourcemap_json = uglifier.compile_with_map(input[:data])
+    compressed_data, sourcemap_json = @uglifier.compile_with_map(data)
 
+    sourcemap = prepare_sourcemap(sourcemap_json, name, data)
+    sourcemap_json = sourcemap.to_json
+
+    sourcemap_filename = "honeycrisp.min.js.map"
+    sourcemap_path = File.join(Dir.pwd, 'dist', 'js', sourcemap_filename)
+
+    write_sourcemap(sourcemap_path, sourcemap_json)
+
+    compressed_data.concat "\n//# sourceMappingURL=#{sourcemap_filename}\n"
+  end
+
+  private
+
+  def prepare_sourcemap(sourcemap_json, name, data)
     sourcemap = JSON.parse(sourcemap_json)
     sourcemap["sources"] = ["#{name}.js"]
     sourcemap["sourceRoot"] = Dir.pwd
     sourcemap["sourcesContent"] = [data]
-    sourcemap_json = sourcemap.to_json
+    sourcemap
+  end
 
-    sourcemap_filename = "honeycrisp.min.js.map"
-    sourcemap_path = "#{Dir.pwd}/dist/js/#{sourcemap_filename}"
-    sourcemap_url = sourcemap_filename
-
-    FileUtils.mkdir_p File.dirname(sourcemap_path)
-    File.write(sourcemap_path, sourcemap_json)
-
-    compressed_data.concat "\n//# sourceMappingURL=#{sourcemap_url}\n"
+  def write_sourcemap(path, content)
+    FileUtils.mkdir_p File.dirname(path)
+    File.write(path, content)
+  rescue IOError => e
+    raise "Failed to write sourcemap: #{e.message}"
   end
 
   def digest(io)


### PR DESCRIPTION
Move the `uglifier` initialization out of the method to avoid re-initializing it every time the method is called.

Used `File.join` for constructing file paths to ensure compatibility across different operating systems.

Included the necessary `json` and `fileutils` libraries explicitly.