### PR TITLE
Set `.select__element` color to inherit instead of using safari default for `select` elements

### DIFF
--- a/app/assets/stylesheets/honeycrisp/atoms/_form-elements.scss
+++ b/app/assets/stylesheets/honeycrisp/atoms/_form-elements.scss
@@ -209,6 +209,7 @@ label {
   font-family: $font-system;
   font-size: $font-size-25;
   font-weight: $font-weight-bold;
+  color: inherit;
   background-color: transparent;
   width: 100%;
   overflow-wrap: break-word;


### PR DESCRIPTION
[GCF-465](https://codeforamerica.atlassian.net/browse/GCF-465?atlOrigin=eyJpIjoiYTlhOGNhOWEwOGFhNDhlYmIxYmQ0NWEwZjY0NDU1YzEiLCJwIjoiaiJ9)

[GCF-465]: https://codeforamerica.atlassian.net/browse/GCF-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Used to be `-apple-system-blue`:
![Screenshot 2024-07-09 at 2 47 26 PM](https://github.com/codeforamerica/honeycrisp-gem/assets/18129274/125f21a0-7dd0-4e91-bbba-ef019ba21d3b)

No longer blue
![Screenshot 2024-07-09 at 2 44 27 PM](https://github.com/codeforamerica/honeycrisp-gem/assets/18129274/6d0236cf-c64b-418b-a292-a4d62f13532b)
