### PR TITLE
Use url instead of font-url since Rails 8 does not use sprockets

### DIFF
--- a/app/assets/stylesheets/honeycrisp/atoms/_icons.scss
+++ b/app/assets/stylesheets/honeycrisp/atoms/_icons.scss
@@ -56,11 +56,11 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: normal;
-  src: font-url('MaterialIcons-Regular.eot'); /* For IE6-8 */
-  src: font-url('MaterialIcons-Regular.eot?#iefix') format('embedded-opentype'),
-    font-url('MaterialIcons-Regular.ttf') format('truetype'),
-    font-url('MaterialIcons-Regular.woff') format('woff'),
-    font-url('MaterialIcons-Regular.svg') format('svg');
+  src: url('MaterialIcons-Regular.eot'); /* For IE6-8 */
+  src: url('MaterialIcons-Regular.eot?#iefix') format('embedded-opentype'),
+    url('MaterialIcons-Regular.ttf') format('truetype'),
+    url('MaterialIcons-Regular.woff') format('woff'),
+    url('MaterialIcons-Regular.svg') format('svg');
 }
 
 [class^="icon-"], [class*=" icon-"] {


### PR DESCRIPTION
Stems from this conversation about icons not loading in Rails 8 app, due to the fact that Rails 8 by default does not use sprockets but rather uses Propshaft (+ Importmap for JS). The hope here is that by utilizing `url` which is not a sprocket method, it will make the icons available to Rails 8 apps as well as Rails 7 (vita-min and gcf-backend notably uses this)